### PR TITLE
fix: 헤더 프로필 영역 드롭다운 이슈 수정

### DIFF
--- a/src/components/shared/Profile.tsx
+++ b/src/components/shared/Profile.tsx
@@ -3,15 +3,14 @@ import { Icons } from "../icons/Icons"
 import Image from "next/image"
 import Button from "./button/Button"
 import Skeleton from "react-loading-skeleton"
-import { useState } from "react"
+import { ButtonHTMLAttributes, useState } from "react"
 
-interface ProfileProps {
+interface ProfileProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   profileImage?: string | null
   className?: string
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-function Profile({ profileImage, className, onClick }: ProfileProps) {
+function Profile({ profileImage, className, ...props }: ProfileProps) {
   const [imageLoaded, setImageLoaded] = useState(false)
 
   const classNames = {
@@ -24,13 +23,13 @@ function Profile({ profileImage, className, onClick }: ProfileProps) {
 
   if (!profileImage)
     return (
-      <Button className={classNames.noProfile}>
+      <Button className={classNames.noProfile} {...props}>
         <Icons.UserProfile className="text-[30px] leading-8 fill-colorsGray shrink-0" />
       </Button>
     )
 
   return (
-    <Button className={classNames.withProfile} onClick={onClick}>
+    <Button className={classNames.withProfile} {...props}>
       <Image
         className="z-[1]"
         src={profileImage}


### PR DESCRIPTION
## 관련 이슈

close: [#28](https://github.com/KernelSquare/Frontend/issues/28)

## 개요

> 드롭다운 이슈 수정

## 상세 내용

- 프로필 이미지가 없을 경우 클릭시 드롭다운이 보여질 수 있도록 수정
- 확장성을 고려하여 props 수정