### PR TITLE
fix: codesyntaxhighlighter 모듈 에러 해결

### DIFF
--- a/src/page/qna-detail/components/Markdown/MdEditor.tsx
+++ b/src/page/qna-detail/components/Markdown/MdEditor.tsx
@@ -5,13 +5,14 @@ import Prism from "prismjs"
 
 import "tui-color-picker/dist/tui-color-picker.css"
 import { Editor } from "@toast-ui/react-editor"
+import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight"
 // 텍스트 색상 변경 지원
 import colorSyntax from "@toast-ui/editor-plugin-color-syntax"
 // 코드 하이라이트 지원
 import "@toast-ui/editor-plugin-color-syntax/dist/toastui-editor-plugin-color-syntax.css"
 // 전체 언어 지원
 import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css"
-import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js"
+import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js"
 
 import { type RefObject } from "react"
 

--- a/src/page/qna-detail/components/Markdown/MdViewer.tsx
+++ b/src/page/qna-detail/components/Markdown/MdViewer.tsx
@@ -5,7 +5,8 @@ import "prismjs/themes/prism.css"
 // import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight"
 import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css"
 import { useLayoutEffect, useRef } from "react"
-import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js"
+import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight"
+import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js"
 
 interface ViewerProps {
   content: string


### PR DESCRIPTION
## 개요

> fix: codesyntaxhighlighter 모듈 에러 해결

## 상세 내용

- codesyntaxhighlighter에서 전체 언어 highlighting이 가능하도록 해결하였습니다.
