### PR TITLE
refactor: useUser 관련 로직 useClientSession으로 수정

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,5 +1,7 @@
+import AuthGuardModal from "@/components/shared/auth-modal/AuthGuardModal"
 import { layoutMeta } from "@/constants/layoutMeta"
 import MyPage from "@/page/profile/MyPage"
+import { isLogined } from "@/util/auth"
 import { Metadata } from "next"
 
 export const metadata: Metadata = {
@@ -8,5 +10,8 @@ export const metadata: Metadata = {
 }
 
 export default function ProfilePage() {
+  if (!isLogined()) {
+    return <AuthGuardModal page="question" />
+  }
   return <MyPage />
 }

--- a/src/components/layout/navigation/SideNavigation.tsx
+++ b/src/components/layout/navigation/SideNavigation.tsx
@@ -27,7 +27,7 @@ function SideNavigation({ hasHeader }: SideNavigationProps) {
     !hasHeader && "sm:top-0 sm:h-screen",
   ])
 
-const { user } = useClientSession()
+  const { user } = useClientSession()
 
   // 로그인 된 사용자만 profile 탭 보이도록
   return (

--- a/src/constants/navigationRoute.tsx
+++ b/src/constants/navigationRoute.tsx
@@ -25,6 +25,9 @@ export const navigationRoutes = [
     to: "/faq",
     activeClassName: "text-blue-400",
   },
+]
+
+export const profileRoute = [
   {
     label: "마이 페이지",
     icon: NavigationIcons.MyPage,

--- a/src/mocks/db/answers.ts
+++ b/src/mocks/db/answers.ts
@@ -1,4 +1,5 @@
 import type { Answer } from "@/interfaces/answer"
+import badge_url from "@/assets/images/badges"
 
 const mockAnswers: Answer[] = [
   {
@@ -7,7 +8,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 1,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[1],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "zi존",
@@ -24,7 +25,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 2,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[2],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "홍주광",
@@ -41,7 +42,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 3,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[3],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified",
@@ -58,7 +59,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 4,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[4],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified1",
@@ -75,7 +76,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 5,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[5],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified2",
@@ -92,7 +93,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 6,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[6],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified3",
@@ -109,7 +110,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 7,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[7],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified4",
@@ -126,7 +127,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 8,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[8],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified5",
@@ -143,7 +144,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 9,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[9],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified6",
@@ -160,7 +161,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 10,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[10],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified7",
@@ -177,7 +178,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 1,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[1],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified8",
@@ -194,7 +195,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 2,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[2],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified9",
@@ -211,7 +212,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 3,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[3],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified",
@@ -228,7 +229,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 4,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[4],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified1",
@@ -245,7 +246,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 5,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[5],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified",
@@ -262,7 +263,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 6,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[6],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified",
@@ -279,7 +280,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 7,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[7],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified1",
@@ -296,7 +297,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 8,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[8],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified",
@@ -313,7 +314,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 9,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[9],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified1",
@@ -330,7 +331,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 10,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[10],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified",
@@ -347,7 +348,7 @@ const mockAnswers: Answer[] = [
     content:
       "Integer pede justo, lacinia eget, tincidunt eget, tempus vel, pede. Morbi porttitor lorem id ligula. Suspendisse ornare consequat lectus.",
     author_level: 1,
-    rank_image_url: "rankUrl",
+    rank_image_url: badge_url[1],
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     created_by: "Aerified1",

--- a/src/mocks/db/questions.ts
+++ b/src/mocks/db/questions.ts
@@ -53,8 +53,7 @@ export const mockQuestions: Array<Question> = [
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     level: 4,
-    level_image_url:
-      "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
+    level_image_url: badge_url[4],
     skills: ["javascript", "react"],
     created_date: "2023-12-16T18:09:02",
     modified_date: "2023-12-16T18:09:02",
@@ -73,8 +72,7 @@ export const mockQuestions: Array<Question> = [
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     close_status: false,
     level: 4,
-    level_image_url:
-      "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
+    level_image_url: badge_url[4],
     skills: ["java", "docker", "jpa"],
     created_date: "2023-12-16T17:00:22",
     modified_date: "2023-12-16T17:00:22",
@@ -92,8 +90,7 @@ export const mockQuestions: Array<Question> = [
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     level: 4,
-    level_image_url:
-      "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
+    level_image_url: badge_url[4],
     skills: ["java"],
     created_date: "2023-12-16T12:01:01",
     modified_date: "2023-12-16T12:01:01",
@@ -111,8 +108,7 @@ export const mockQuestions: Array<Question> = [
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     level: 4,
-    level_image_url:
-      "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
+    level_image_url: badge_url[4],
     skills: ["python"],
     created_date: "2023-12-16T07:20:55",
     modified_date: "2023-12-16T07:20:55",
@@ -129,8 +125,7 @@ export const mockQuestions: Array<Question> = [
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     level: 4,
-    level_image_url:
-      "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
+    level_image_url: badge_url[4],
     skills: ["next.js", "react"],
     created_date: "2023-12-15T22:10:12",
     modified_date: "2023-12-15T22:10:12",
@@ -147,8 +142,7 @@ export const mockQuestions: Array<Question> = [
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     level: 4,
-    level_image_url:
-      "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
+    level_image_url: badge_url[4],
     skills: ["java"],
     created_date: "2023-12-14T02:30:35",
     modified_date: "2023-12-14T02:30:35",
@@ -165,8 +159,7 @@ export const mockQuestions: Array<Question> = [
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     level: 4,
-    level_image_url:
-      "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
+    level_image_url: badge_url[4],
     skills: ["typescript", "react"],
     created_date: "2023-12-14T02:09:00",
     modified_date: "2023-12-14T02:09:00",
@@ -183,8 +176,7 @@ export const mockQuestions: Array<Question> = [
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     level: 4,
-    level_image_url:
-      "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
+    level_image_url: badge_url[4],
     skills: ["node.js"],
     created_date: "2023-12-13T22:41:12",
     modified_date: "2023-12-13T22:41:12",
@@ -201,8 +193,7 @@ export const mockQuestions: Array<Question> = [
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     level: 4,
-    level_image_url:
-      "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
+    level_image_url: badge_url[4],
     skills: ["java", "java"],
     created_date: "2023-12-13T08:37:21",
     modified_date: "2023-12-13T08:37:21",
@@ -219,8 +210,7 @@ export const mockQuestions: Array<Question> = [
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     level: 4,
-    level_image_url:
-      "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
+    level_image_url: badge_url[4],
     skills: ["java"],
     created_date: "2023-12-13T06:10:12",
     modified_date: "2023-12-13T06:10:12",
@@ -237,8 +227,7 @@ export const mockQuestions: Array<Question> = [
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     level: 4,
-    level_image_url:
-      "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
+    level_image_url: badge_url[4],
     skills: ["java"],
     created_date: "2023-12-12T05:51:50",
     modified_date: "2023-12-15T05:51:50",
@@ -255,8 +244,7 @@ export const mockQuestions: Array<Question> = [
     member_image_url:
       "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
     level: 4,
-    level_image_url:
-      "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg",
+    level_image_url: badge_url[4],
     skills: ["java"],
     created_date: "2023-12-11T12:10:12",
     modified_date: "2023-12-11T12:10:12",

--- a/src/page/profile/MyPage.tsx
+++ b/src/page/profile/MyPage.tsx
@@ -5,60 +5,44 @@ import ProfileImage from "./components/ProfileImage"
 import ExperiencePoint from "./components/ExperiencePoint"
 import { basic_profile } from "@/assets/images/basic"
 import badge_url from "@/assets/images/badges"
-import ContentLoading from "@/components/shared/animation/ContentLoading"
 import Introduction from "./components/Introduction"
-import { useEffect } from "react"
-import { useUser } from "@/hooks/useUser"
 import { twMerge } from "tailwind-merge"
+import { useClientSession } from "@/hooks/useClientSession"
 
 // 아이디 값 관련 로직 수정 예정
 function MyPage() {
-  const { data: member, refetch, isPending } = useUser()
-  console.log("useuser", member?.data)
+  const { user } = useClientSession()
 
-  useEffect(() => {
-    refetch()
-  }, [])
-
-  if (isPending) return <Loading />
-
-  if (member?.data.data)
+  if (user)
     return (
       <div className="max-w-[60%] m-auto mt-[50px]">
         <div className="w-full flex justify-evenly mb-[50px]">
           <ProfileImage
-            id={member?.data.data.id}
+            id={user.member_id}
             image_url={
-              member?.data.data.image_url &&
-              typeof member?.data.data.image_url === "string"
-                ? member?.data.data.image_url
+              user.image_url && typeof user.image_url === "string"
+                ? user.image_url
                 : basic_profile
             }
           />
           <div className="flex items-center">
             <div>
               <Image
-                src={badge_url[member?.data.data.level]}
+                src={badge_url[user.level]}
                 alt="배지 이미지"
                 width={50}
                 height={50}
               />
-              <div className="text-center">level {member?.data.data.level}</div>
+              <div className="text-center">level {user.level}</div>
             </div>
             <div className="font-bold text-[48px] ml-[20px]">
-              {member?.data.data.nickname}
+              {user.nickname}
             </div>
           </div>
         </div>
-        <ExperiencePoint
-          level={member?.data.data.level}
-          exp={member?.data.data.experience}
-        />
+        <ExperiencePoint level={user.level} exp={user.experience} />
         <Divider className="mb-[50px]" />
-        <Introduction
-          introduction={member?.data.data.introduction}
-          id={member?.data.data.id}
-        />
+        <Introduction introduction={user.introduction} id={user.member_id} />
         <Divider />
       </div>
     )
@@ -73,18 +57,4 @@ interface DividerProps {
 function Divider({ className }: DividerProps) {
   const classMerged = twMerge(["h-[3px] bg-slate-400 w-full", className])
   return <div className={classMerged}></div>
-}
-
-function Loading() {
-  return (
-    <div className="h-full">
-      <ContentLoading
-        style={{
-          width: "calc(100% - 80px)",
-          maxWidth: "400px",
-          margin: "0 auto",
-        }}
-      />
-    </div>
-  )
 }

--- a/src/page/qna-detail/QnADetail.tsx
+++ b/src/page/qna-detail/QnADetail.tsx
@@ -6,18 +6,16 @@ import MyAnswer from "./components/MyAnswer"
 import AnswerList from "./components/Answers/AnswerList"
 import { questionQueries } from "@/react-query/question"
 import ContentLoading from "@/components/shared/animation/ContentLoading"
-import { useNickname } from "@/hooks/useUser"
-import { useRecoilState } from "recoil"
-import { AnswerMode } from "@/recoil/atoms/mode"
 import type { Answer } from "@/interfaces/answer"
 import { answerQueries } from "@/react-query/answers"
+import { useClientSession } from "@/hooks/useClientSession"
 
 const QnADetail: React.FC<{ id: string }> = ({ id }) => {
   const { data, isPending } = questionQueries.useQuestionData({
     id: Number(id),
   })
 
-  const { data: member, refetch } = useNickname()
+  const { user } = useClientSession()
 
   const { data: answers, isPending: isAnswerPending } =
     answerQueries.useGetAnswers({
@@ -33,15 +31,15 @@ const QnADetail: React.FC<{ id: string }> = ({ id }) => {
     const fetchData = async () => {
       if (
         answers?.data &&
-        member &&
-        !handleCheckMyAnswer(answers.data, member)
+        user?.nickname &&
+        !handleCheckMyAnswer(answers.data, user.nickname)
       ) {
         setIsAnswerMode(true)
       }
     }
 
     fetchData()
-  }, [answers, member])
+  }, [answers, user?.nickname])
 
   if (isPending || isAnswerPending || !data) return <Loading />
 
@@ -57,7 +55,7 @@ const QnADetail: React.FC<{ id: string }> = ({ id }) => {
             setIsAnswerMode={setIsAnswerMode}
           />
           <Title title="Answers" />
-          <AnswerList user={member} id={Number(id)} />
+          <AnswerList user={user?.nickname} id={Number(id)} />
         </div>
       </div>
     )

--- a/src/page/qna-detail/components/Answers/OneAnswer.tsx
+++ b/src/page/qna-detail/components/Answers/OneAnswer.tsx
@@ -15,7 +15,6 @@ import queryKey from "@/constants/queryKey"
 import badge_url from "@/assets/images/badges"
 import type { Editor } from "@toast-ui/react-editor"
 import { useForm } from "react-hook-form"
-import mockAnswers from "@/mocks/db/answers"
 
 const MdViewer = dynamic(() => import("../Markdown/MdViewer"), {
   ssr: false,

--- a/src/page/qna-detail/components/MyAnswer.tsx
+++ b/src/page/qna-detail/components/MyAnswer.tsx
@@ -1,30 +1,16 @@
 "use client"
 
 import dynamic from "next/dynamic"
-import {
-  PropsWithChildren,
-  SetStateAction,
-  useEffect,
-  useRef,
-  useState,
-} from "react"
+import { PropsWithChildren, useRef } from "react"
 import { useForm } from "react-hook-form"
 import { Editor } from "@toast-ui/react-editor"
 import Button from "@/components/shared/button/Button"
-import { useRecoilState } from "recoil"
-import { AnswerMode } from "@/recoil/atoms/mode"
 import { createAnswer } from "@/service/answers"
 import { useQueryClient } from "@tanstack/react-query"
-import queryKey from "@/constants/queryKey"
 import CreateAnswerAnime from "@/components/shared/animation/CreateAnswerAnime"
 import useModal from "@/hooks/useModal"
-import { getCookie } from "cookies-next"
-import { ACCESS_TOKEN_KEY } from "@/constants/token"
 import LoginForm from "@/components/form/LoginForm"
-import { useProgressModal } from "@/hooks/useProgressModal"
-import { sleep } from "@/util/sleep"
 import { useClientSession } from "@/hooks/useClientSession"
-
 
 const MdEditor = dynamic(() => import("./Markdown/MdEditor"), {
   ssr: false,
@@ -35,7 +21,7 @@ const MyAnswer: React.FC<{
   isAnswerMode: boolean
   setIsAnswerMode: React.Dispatch<React.SetStateAction<boolean>>
 }> = ({ id, isAnswerMode, setIsAnswerMode }) => {
-   const { openModal } = useModal()
+  const { openModal } = useModal()
 
   const { handleSubmit } = useForm()
   const editorRef = useRef<Editor>(null)
@@ -46,12 +32,12 @@ const MyAnswer: React.FC<{
   const handleSubmitValue = async () => {
     const submitValue = editorRef.current?.getInstance().getMarkdown()
     console.log("md", submitValue)
-    
+
     try {
-      if (member_id)
+      if (user?.member_id)
         createAnswer({
           questionId: id,
-          member_id,
+          member_id: user.member_id,
           content: submitValue || "",
         }).then((res) => {
           console.log("res", res.data.msg, res.config.data)
@@ -95,7 +81,7 @@ const MyAnswer: React.FC<{
     </div>
   )
 
-if (!user)
+  if (!user)
     return (
       <Container>
         <WithoutToken />


### PR DESCRIPTION
## 관련 이슈

close: [#32](https://github.com/KernelSquare/Frontend/issues/32)

## 개요

> useUser 관련 로직을 useClientSession으로 수정

## 상세 내용

- 기존에 `useUser` 유틸 함수를 통해 구현되었던 부분을 @Ryan-TheLion 님께서 구현하신 `useClientSession`을 사용하도록 로직을 수정하였습니다.
