### PR TITLE
feat: 프로필 정보 수정 관련 API 변동 사항 반영

### DIFF
--- a/src/assets/images/basic.ts
+++ b/src/assets/images/basic.ts
@@ -1,2 +1,5 @@
 export const basic_profile =
   "https://mobirise.com/bootstrap-template//profile-template/assets/images/timothy-paul-smith-256424-1200x800.jpg"
+
+export const basic_profile_background =
+  "https://images.unsplash.com/photo-1516727052521-08079c40df80?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"

--- a/src/constants/response/member.ts
+++ b/src/constants/response/member.ts
@@ -37,7 +37,7 @@ export const MemberApiStatus = {
     },
   },
   /**
-   * 회원 정보 수정 관련 api status
+   * 회원 정보 수정 관련 api status (자기소개 수정 + 프로필 이미지 수정)
    */
   updateMember: {
     /**

--- a/src/interfaces/dto/member/update-member-introduction.dto.ts
+++ b/src/interfaces/dto/member/update-member-introduction.dto.ts
@@ -1,0 +1,12 @@
+import type { User } from "@/interfaces/user"
+import type { APIResponse } from "../api-response"
+
+export interface UpdateMemberIntroductionRequest
+  extends Partial<Pick<User, "introduction">> {
+  memberId: number
+}
+
+export interface UpdateMemberIntroductionResponse extends APIResponse {
+  code: number
+  msg: string
+}

--- a/src/interfaces/dto/member/update-member-profile-image-dto.ts
+++ b/src/interfaces/dto/member/update-member-profile-image-dto.ts
@@ -1,0 +1,12 @@
+import type { User } from "@/interfaces/user"
+import type { APIResponse } from "../api-response"
+
+export interface UpdateMemberProfileImageRequest
+  extends Partial<Pick<User, "image_url">> {
+  memberId: number
+}
+
+export interface UpdateMemberProfileImageResponse extends APIResponse {
+  code: number
+  msg: string
+}

--- a/src/mocks/handler/member.ts
+++ b/src/mocks/handler/member.ts
@@ -10,6 +10,14 @@ import {
   UpdateMemberInfoResponse,
 } from "@/interfaces/dto/member/update-member-info.dto"
 import { ApiStatus } from "@/constants/response/api"
+import type {
+  UpdateMemberIntroductionRequest,
+  UpdateMemberIntroductionResponse,
+} from "@/interfaces/dto/member/update-member-introduction.dto"
+import type {
+  UpdateMemberProfileImageRequest,
+  UpdateMemberProfileImageResponse,
+} from "@/interfaces/dto/member/update-member-profile-image-dto"
 
 export const memberHandler = [
   http.get<{ id: string }, DefaultBodyType, GetMemberResponse>(
@@ -88,6 +96,7 @@ export const memberHandler = [
       }
     },
   ),
+  // 일반 회원 정보 수정
   http.put<
     { id: string },
     Omit<UpdateMemberInfoRequest, "id">,
@@ -110,6 +119,64 @@ export const memberHandler = [
         {
           code: Code,
           msg: "회원 정보 수정 완료",
+        },
+        { status: HttpStatus },
+      )
+    },
+  ),
+  // 회원 자기소개 수정
+  http.put<
+    { id: string },
+    Omit<UpdateMemberIntroductionRequest, "memberId">,
+    UpdateMemberIntroductionResponse
+  >(
+    `${
+      process.env.NEXT_PUBLIC_SERVER
+    }${RouteMap.member.updateMemberIntroduction()}`,
+    async ({ request, params }) => {
+      // 정보 수정
+      const userId = params.id
+      const { introduction } = await request.json()
+
+      const target = mockUsers.find((user) => user.id === Number(userId))!
+      target.introduction = introduction
+
+      const { Code, HttpStatus } = ApiStatus.Member.updateMember.Ok
+
+      return HttpResponse.json(
+        {
+          code: Code,
+          msg: "회원 정보 수정 성공",
+        },
+        { status: HttpStatus },
+      )
+    },
+  ),
+  // 회원 프로필 이미지 수정
+  http.put<
+    { id: string },
+    Omit<UpdateMemberProfileImageRequest, "memberId">,
+    UpdateMemberProfileImageResponse
+  >(
+    `${
+      process.env.NEXT_PUBLIC_SERVER
+    }${RouteMap.member.updateMemberProfileImage()}`,
+    async ({ request, params }) => {
+      // 정보 수정
+      console.log("프로필 이미지 수정")
+      const userId = params.id
+      const { image_url } = await request.json()
+
+      const target = mockUsers.find((user) => user.id === Number(userId))!
+
+      if (typeof image_url !== "undefined") target.image_url = image_url
+
+      const { Code, HttpStatus } = ApiStatus.Member.updateMember.Ok
+
+      return HttpResponse.json(
+        {
+          code: Code,
+          msg: "회원 정보 수정 성공",
         },
         { status: HttpStatus },
       )

--- a/src/page/user-profile/components/UserProfileMenu.tsx
+++ b/src/page/user-profile/components/UserProfileMenu.tsx
@@ -21,7 +21,7 @@ function UserProfileMenu({ userPayload }: UserProfileMenuProps) {
   const { user } = useClientSession()
   const isMyPage = userPayload.id === user?.member_id
   const [menu, setMenu] = useState<MenuKey>("Introduction")
-  const { handleEditMode } = useIntroduction()
+  const { handleIntroductionEditMode } = useIntroduction()
 
   const MenuContent = () => {
     switch (menu) {
@@ -55,7 +55,7 @@ function UserProfileMenu({ userPayload }: UserProfileMenuProps) {
                 {isMyPage && (
                   <Icons.EditIntro
                     className="ml-[2px] text-[16px] mt-[6px] hrink-0 cursor-pointer"
-                    onClick={handleEditMode}
+                    onClick={handleIntroductionEditMode}
                   />
                 )}
               </div>

--- a/src/page/user-profile/components/UserProfilePresenter.tsx
+++ b/src/page/user-profile/components/UserProfilePresenter.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { Icons } from "@/components/icons/Icons"
 import Spacing from "@/components/shared/Spacing"
 import { UserPayload } from "@/interfaces/dto/member/get-member.dto"
 import Image from "next/image"
@@ -9,10 +8,8 @@ import UserProfileSection from "./UserProfileSection"
 import UserProfileMenu from "./UserProfileMenu"
 import badge_url from "@/assets/images/badges"
 import levelStandard from "@/constants/levelStandard"
-import { useClientSession } from "@/hooks/useClientSession"
-import Button from "@/components/shared/button/Button"
-import { buttonMessage } from "@/constants/message"
-import useProfileImage from "../hooks/useProfileImage"
+import ProfileImage from "./profileImage/ProfileImage"
+import { basic_profile_background } from "@/assets/images/basic"
 
 interface UserProfilePresenterProps {
   userPayload: UserPayload
@@ -53,9 +50,7 @@ UserProfilePresenter.BackgroundSection =
     return (
       <div className="relative w-full h-0 pb-36 sm:aspect-video sm:max-h-[400px] sm:h-fit bg-colorsLightGray">
         <Image
-          src={
-            "https://images.unsplash.com/photo-1516727052521-08079c40df80?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-          }
+          src={basic_profile_background}
           alt="bg"
           fill
           style={{ objectFit: "cover" }}
@@ -69,49 +64,12 @@ UserProfilePresenter.UserInfo = function UserProfileInfo({
 }: {
   userPayload: UserPayload
 }) {
-  const { user } = useClientSession()
-  const isMyPage = user?.member_id === userPayload.id
-  const { handleImageChange, handleUpload } = useProfileImage({
-    image_url: userPayload.image_url!,
-  })
-  const imageUploadRef = useRef<HTMLInputElement>(null)
-
-  if (!userPayload.image_url)
-    return (
-      <ProfileImageWrapper userPayload={userPayload}>
-        <div className="relative w-[120px] h-[120px] rounded-full overflow-hidden [&_svg]:w-[120px] [&>svg]:h-[120px]">
-          <Icons.UserProfile className="absolute text-colorsGray bg-white" />
-        </div>
-      </ProfileImageWrapper>
-    )
-
   return (
     <ProfileImageWrapper userPayload={userPayload}>
-      <div className="relative w-[120px] h-[120px] rounded-full overflow-hidden [&_svg]:w-[120px] [&>svg]:h-[120px]">
-        <Image
-          src={userPayload.image_url}
-          alt={`profile`}
-          fill
-          style={{ objectFit: "cover", objectPosition: "center" }}
-        />
-      </div>
-      <input
-        type="file"
-        ref={imageUploadRef}
-        className="hidden"
-        accept="image/*"
-        onChange={(e) => handleImageChange(e, userPayload.id)}
+      <ProfileImage
+        user_id={userPayload.id}
+        image_url={userPayload.image_url}
       />
-      {isMyPage && (
-        <Button
-          type="button"
-          buttonTheme="primary"
-          className="max-w-[100px] h-[30px] my-3"
-          onClick={() => handleUpload(imageUploadRef)}
-        >
-          {buttonMessage.updateProfile}
-        </Button>
-      )}
     </ProfileImageWrapper>
   )
 }

--- a/src/page/user-profile/components/introduction/Introduction.tsx
+++ b/src/page/user-profile/components/introduction/Introduction.tsx
@@ -4,14 +4,12 @@ import { useForm } from "react-hook-form"
 import useIntroduction from "../../hooks/useIntroduction"
 import type { IntroductionProps } from "./Introduction.types"
 import type { IntroductionValue } from "../../hooks/useIntroduction.types"
-import { useRef, useState } from "react"
-import { twJoin } from "tailwind-merge"
+import { useRef } from "react"
 import {
   buttonMessage,
   errorMessage,
   notificationMessage,
 } from "@/constants/message"
-import Textarea from "@/components/shared/textarea/Textarea"
 import Button from "@/components/shared/button/Button"
 import UserProfileMenu from "../UserProfileMenu"
 import dynamic from "next/dynamic"
@@ -24,8 +22,11 @@ const MdEditor = dynamic(() => import("./MdEditor"), {
 
 function Introduction({ introduction, isMyPage }: IntroductionProps) {
   const editorRef = useRef<Editor>(null)
-  const { closeEditMode, handleSubmitIntroduction, isEditMode } =
-    useIntroduction()
+  const {
+    closeIntroductionEditMode,
+    handleSubmitIntroduction,
+    isIntroductionEditMode,
+  } = useIntroduction()
   const { handleSubmit } = useForm<IntroductionValue>()
 
   const onsubmit = () => {
@@ -45,7 +46,7 @@ function Introduction({ introduction, isMyPage }: IntroductionProps) {
     )
   }
 
-  if (isMyPage && isEditMode)
+  if (isMyPage && isIntroductionEditMode)
     return (
       <UserProfileMenu.MenuContentWrapper>
         <div>
@@ -55,7 +56,7 @@ function Introduction({ introduction, isMyPage }: IntroductionProps) {
               <Button
                 buttonTheme="third"
                 className="w-[70px] mr-[10px]"
-                onClick={closeEditMode}
+                onClick={closeIntroductionEditMode}
               >
                 {buttonMessage.cancle}
               </Button>

--- a/src/page/user-profile/components/profileImage/ProfileImage.tsx
+++ b/src/page/user-profile/components/profileImage/ProfileImage.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { Icons } from "@/components/icons/Icons"
+import Button from "@/components/shared/button/Button"
+import { buttonMessage } from "@/constants/message"
+import Image from "next/image"
+import useProfileImage from "../../hooks/useProfileImage"
+import { useClientSession } from "@/hooks/useClientSession"
+import { useRef } from "react"
+
+type ProfileImageProps = {
+  user_id: number
+  image_url: string | null
+}
+
+const ProfileImage = ({ user_id, image_url }: ProfileImageProps) => {
+  const { user } = useClientSession()
+  const isMyPage = user?.member_id === user_id
+  const { handleImageChange, handleUpload } = useProfileImage({
+    image_url: image_url!,
+  })
+  const imageUploadRef = useRef<HTMLInputElement>(null)
+
+  if (!image_url) return <NoProfileImage />
+
+  return (
+    <>
+      <div className="relative w-[120px] h-[120px] rounded-full overflow-hidden [&_svg]:w-[120px] [&>svg]:h-[120px]">
+        <Image
+          src={image_url}
+          alt={`profile`}
+          fill
+          style={{ objectFit: "cover", objectPosition: "center" }}
+        />
+      </div>
+      <input
+        type="file"
+        ref={imageUploadRef}
+        className="hidden"
+        accept="image/*"
+        onChange={(e) => handleImageChange(e, user_id)}
+      />
+      {isMyPage && (
+        <Button
+          type="button"
+          buttonTheme="primary"
+          className="max-w-[100px] h-[30px] my-3"
+          onClick={() => handleUpload(imageUploadRef)}
+        >
+          {buttonMessage.updateProfile}
+        </Button>
+      )}
+    </>
+  )
+}
+
+export default ProfileImage
+
+function NoProfileImage() {
+  return (
+    <div className="relative w-[120px] h-[120px] rounded-full overflow-hidden [&_svg]:w-[120px] [&>svg]:h-[120px]">
+      <Icons.UserProfile className="absolute text-colorsGray bg-white" />
+    </div>
+  )
+}

--- a/src/react-query/member.ts
+++ b/src/react-query/member.ts
@@ -1,9 +1,21 @@
 import queryKey from "@/constants/queryKey"
-import { GetMemberRequest } from "@/interfaces/dto/member/get-member.dto"
-import { UpdateMemberInfoRequest } from "@/interfaces/dto/member/update-member-info.dto"
-import { getMemeber, updateMemberInfo } from "@/service/member"
+import type { GetMemberRequest } from "@/interfaces/dto/member/get-member.dto"
+import type { UpdateMemberInfoRequest } from "@/interfaces/dto/member/update-member-info.dto"
+import type { UpdateMemberIntroductionRequest } from "@/interfaces/dto/member/update-member-introduction.dto"
+import type { UpdateMemberProfileImageRequest } from "@/interfaces/dto/member/update-member-profile-image-dto"
+import {
+  getMemeber,
+  updateMemberInfo,
+  updateMemberIntroduction,
+  updateMemberProfileImage,
+} from "@/service/member"
 import { keepPreviousData, useMutation, useQuery } from "@tanstack/react-query"
 
+/**
+ *
+ * @param param0 id: 사용자 id
+ * @returns payload.data.data
+ */
 const useMemberData = ({ id }: GetMemberRequest) =>
   useQuery({
     queryKey: [queryKey.member],
@@ -25,7 +37,63 @@ const useUpdateInfo = ({
     mutationFn: () => updateMemberInfo({ id, image_url, introduction }),
   })
 
+/**
+ *
+ * @description 사용자 자기소개 수정
+ * @param UpdateMemberIntroductionRequest
+ */
+const useUpdateMemberIntroduction = () => {
+  const {
+    mutate: updateMemberIntroductionMutate,
+    isPending: isUpdateMemberIntroduction,
+    isError: isUpdateMemberIntroductionError,
+    isSuccess: isUpdateMemberIntroductionSuccess,
+  } = useMutation({
+    mutationKey: [queryKey.member, queryKey.updateInfo],
+    mutationFn: ({ memberId, introduction }: UpdateMemberIntroductionRequest) =>
+      updateMemberIntroduction({ memberId, introduction }),
+  })
+
+  return {
+    updateMemberIntroduction: updateMemberIntroductionMutate,
+    updateMemberIntroductionStatus: {
+      isUpdateMemberIntroduction,
+      isUpdateMemberIntroductionError,
+      isUpdateMemberIntroductionSuccess,
+    },
+  }
+}
+
+/**
+ *
+ * @description 사용자 프로필 이미지 수정
+ * @param UpdateMemberProfileImageRequest
+ */
+const useUpdateMemberProfileImage = () => {
+  const {
+    mutate: updateMemberProfileImageMutate,
+    isPending: isUpdateMemberProfileImage,
+    isError: isUpdateMemberProfileImageError,
+    isSuccess: isUpdateMemberProfileImageSuccess,
+  } = useMutation({
+    mutationKey: [queryKey.member, queryKey.updateInfo],
+    mutationFn: ({ memberId, image_url }: UpdateMemberProfileImageRequest) =>
+      updateMemberProfileImage({ memberId, image_url }),
+  })
+
+  return {
+    updateMemberProfileImage: updateMemberProfileImageMutate,
+    updateMemberProfileImageStatus: {
+      isUpdateMemberProfileImage,
+      isUpdateMemberProfileImageError,
+      isUpdateMemberProfileImageSuccess,
+    },
+  }
+}
+
 export const memberQueries = {
   useMemberData,
   useUpdateInfo,
+  useUpdateMemberIntroduction,
+  useUpdateMemberProfileImage,
 }

--- a/src/service/member.ts
+++ b/src/service/member.ts
@@ -9,7 +9,20 @@ import {
   UpdateMemberInfoResponse,
 } from "@/interfaces/dto/member/update-member-info.dto"
 import { AxiosResponse } from "axios"
+import {
+  UpdateMemberIntroductionRequest,
+  UpdateMemberIntroductionResponse,
+} from "@/interfaces/dto/member/update-member-introduction.dto"
+import {
+  UpdateMemberProfileImageRequest,
+  UpdateMemberProfileImageResponse,
+} from "@/interfaces/dto/member/update-member-profile-image-dto"
 
+/**
+ *
+ * @param param0 id: 사용자 id
+ * @returns res: 사용자 정보 조회 결과과
+ */
 export async function getMemeber({ id }: GetMemberRequest) {
   const res = await apiInstance.get<GetMemberResponse>(
     RouteMap.member.getMember(id),
@@ -31,6 +44,48 @@ export async function updateMemberInfo({
   >(RouteMap.member.updateMemberInfo(id), {
     ...(nickname && { nickname }),
     introduction,
+    image_url,
+  })
+
+  return res
+}
+
+/**
+ *
+ * @param param0 memberId: 사용자 id (number)
+ * @param param1 introduction: 수정된 자기소개 내용 (string)
+ * @returns res: 사용자 자기소개 수정 결과
+ */
+export async function updateMemberIntroduction({
+  memberId,
+  introduction,
+}: UpdateMemberIntroductionRequest) {
+  const res = await apiInstance.put<
+    any,
+    AxiosResponse<UpdateMemberIntroductionResponse>,
+    Omit<UpdateMemberIntroductionRequest, "memberId">
+  >(RouteMap.member.updateMemberIntroduction(memberId), {
+    introduction,
+  })
+
+  return res
+}
+
+/**
+ *
+ * @param param0 memberId: 사용자 id (number)
+ * @param param1 introduction: 수정된 프로필 이미지 URL (string | null)
+ * @returns res: 사용자 프로필 이미지 수정 결과
+ */
+export async function updateMemberProfileImage({
+  memberId,
+  image_url,
+}: UpdateMemberProfileImageRequest) {
+  const res = await apiInstance.put<
+    any,
+    AxiosResponse<UpdateMemberProfileImageResponse>,
+    Omit<UpdateMemberProfileImageRequest, "memberId">
+  >(RouteMap.member.updateMemberProfileImage(memberId), {
     image_url,
   })
 

--- a/src/service/route-map.ts
+++ b/src/service/route-map.ts
@@ -31,7 +31,9 @@ export class RouteMap {
    *
    * **getMember**: 특정멤버조회(GET)
    *
-   * **updateMemberInfo**: 회원정보수정(PUT)
+   * **updateMemberIntroduction**: 회원 소개 수정(PUT)
+   *
+   * **updateMemberProfileImage**: 회원 프로필 이미지 수정 (PUT)
    *
    * **updatePassword**: 회원 패스워드 수정(PUT)
    *
@@ -53,6 +55,16 @@ export class RouteMap {
       return `${RouteMap.routeGroupBaseURL.member}/${
         memberId === undefined ? ":id" : memberId
       }`
+    },
+    updateMemberIntroduction(memberId?: number) {
+      return `${RouteMap.routeGroupBaseURL.member}/${
+        memberId === undefined ? ":id" : memberId
+      }/introduction`
+    },
+    updateMemberProfileImage(memberId?: number) {
+      return `${RouteMap.routeGroupBaseURL.member}/${
+        memberId === undefined ? ":id" : memberId
+      }/profile`
     },
     updatePassword(memberId?: number) {
       return `${RouteMap.routeGroupBaseURL.member}/${


### PR DESCRIPTION
## 관련 이슈

close: [#54 ](https://github.com/KernelSquare/Frontend/issues/54)

## 개요

> 마이페이지 수정 기능을 변경된 API에 맞춰 리팩토링 하였습니다.

## 상세 내용

- 기존에 하나의 API를 사용하던 마이페이지 수정 기능을 자기소개 수정 / 프로필 이미지 수정 API로 분리하여 요청하도록 타입 및 msw 로직 등을 변경하였습니다.