### PR TITLE
fix: 답변 에디터에서 이미지 중복 제출 오류 해결

### DIFF
--- a/src/page/qna-detail/components/Markdown/MdEditor.tsx
+++ b/src/page/qna-detail/components/Markdown/MdEditor.tsx
@@ -16,6 +16,7 @@ import { Editor } from "@toast-ui/react-editor"
 import type { RefObject } from "react"
 import { toast } from "react-toastify"
 import { useRecoilState, useSetRecoilState } from "recoil"
+import { useAnswerToastUiEditorImageUploadHook } from "../../hooks/useToastUiEditorImageUploadHook"
 
 export interface EditorProps {
   answerId?: number
@@ -38,8 +39,8 @@ const MdEditor: React.FC<EditorProps> = ({
     answerEditorLoadedAtomFamily(answerId ?? -1),
   )
 
-  const { uploadImageHook } = useToastUiEditorImageUploadHook({
-    atomKey: answerId + "",
+  const { uploadImageHook } = useAnswerToastUiEditorImageUploadHook({
+    atomKey: answerId,
     category: "answer",
     onUploadSuccess({ linkUrl }) {
       setEditorState((prev) => ({

--- a/src/page/qna-detail/hooks/useToastUiEditorImageUploadHook.tsx
+++ b/src/page/qna-detail/hooks/useToastUiEditorImageUploadHook.tsx
@@ -1,12 +1,14 @@
 "use client"
 
 import { AxiosError, HttpStatusCode } from "axios"
-import { useUploadImage } from "./image/useUploadImage"
+
 import { useRecoilCallback } from "recoil"
 import { questionEditorAtomFamily } from "@/recoil/atoms/questionEditor"
 import type { HookCallback } from "@/components/shared/toast-ui-editor/editor/EditorWrapper"
 import type { APIResponse } from "@/interfaces/dto/api-response"
 import type { UploadImagesCategory } from "@/interfaces/dto/upload/upload-images.dto"
+import { useUploadImage } from "@/hooks/image/useUploadImage"
+import { answerEditorAtomFamily } from "@/recoil/atoms/answerEditor"
 
 type SuccessCallbackArg = {
   file: File
@@ -34,7 +36,7 @@ type ErrorCallback =
   | ((arg: ErrorCallbackArg) => Promise<void>)
 
 interface UseToastUiEditorImageUploadHookOption {
-  atomKey?: string
+  atomKey?: number
   category: UploadImagesCategory
   action?: "create" | "update"
   maximumUploadImageLength?: number
@@ -50,7 +52,7 @@ export const exceedingUploadableImagesError = new Error(
 
 export const MAXIMUM_UPLOAD_IMAGE_LENGTH = 1
 
-export function useToastUiEditorImageUploadHook({
+export function useAnswerToastUiEditorImageUploadHook({
   atomKey,
   category,
   action,
@@ -63,7 +65,7 @@ export function useToastUiEditorImageUploadHook({
     ({ snapshot }) =>
       async () => {
         const editorSnapshot = await snapshot.getPromise(
-          questionEditorAtomFamily(atomKey ?? action ?? "create"),
+          answerEditorAtomFamily(atomKey ?? -1),
         )
 
         return editorSnapshot
@@ -107,7 +109,6 @@ export function useToastUiEditorImageUploadHook({
   const uploadImageHook = async (blob: File | Blob, callback: HookCallback) => {
     try {
       const { fileUploadImageLinks } = await editorSnapshot()
-      console.log("file_hook", fileUploadImageLinks)
       if (fileUploadImageLinks.length >= maximumUploadImageLength) {
         throw exceedingUploadableImagesError
       }


### PR DESCRIPTION
## 관련 이슈

close: [#75](https://github.com/KernelSquare/Frontend/issues/75)

## 개요

> 답변 에디터에서 공용 이미지 업로드 훅 함수 사용 시 이미지 중복 제출이 막아지지 않는 현상을 해결하였습니다.

## 상세 내용

- 기존 훅 함수가 question 관련 atomFamily에 의존하고 있어 답변 관련 페이지의 에디터에서 동일한 훅 함수 사용 시 이미지가 여러 장 업로드 되어도 에러가 발생하지 않는 문제가 발생하였습니다.
- 이를 해결하기 위해 answer 데이터를 기반으로 한 atomFamily에 의존하는 별도의 훅 함수를 만들었습니다.
- 다만, 기존 코드에서 의존하는 atomFamily만 달라진 것이어서 추후 논의 후 두 훅 함수 중 중복되는 부분은 하나로 합쳐서 분리해도 좋을 것 같아 보입니다.
