### PR TITLE
Feat/frontend#90

### DIFF
--- a/src/page/coffee-chat/create/components/ScheduleSection.tsx
+++ b/src/page/coffee-chat/create/components/ScheduleSection.tsx
@@ -59,7 +59,7 @@ const ScheduleSection = () => {
         </CoffeeChatSection.Label>
         <div className="flex justify-around">
           <div>
-            <CustomCalendar start={startDate} limit={29} />
+            <CustomCalendar start={startDate} limit={21} />
             {!date && (
               <div className="font-bold text-primary mt-3">
                 원하는 시작 일자를 클릭하면 시간대를 설정할 수 있습니다.

--- a/src/page/coffee-chat/create/hooks/useGetScheduleList.tsx
+++ b/src/page/coffee-chat/create/hooks/useGetScheduleList.tsx
@@ -18,7 +18,7 @@ export const useGetScheduleList = (addNum: number) => {
       .add(addNum, "day")
       .format("YYYY-MM-DD")
     const dateTimeStr = `${DAY} ${time}`
-    return `${dayjs(dateTimeStr).add(addNum, "day").utc().format()}`
+    return dayjs(dateTimeStr).add(addNum, "day").utc().format().slice(0, -1)
   })
 }
 

--- a/src/page/coffee-chat/create/hooks/useGetScheduleList.tsx
+++ b/src/page/coffee-chat/create/hooks/useGetScheduleList.tsx
@@ -4,19 +4,22 @@ import {
 } from "@/recoil/atoms/coffee-chat/schedule"
 import dayjs from "dayjs"
 import { useRecoilValue, useSetRecoilState } from "recoil"
+import utc from "dayjs/plugin/utc"
 
 export const useGetScheduleList = (addNum: number) => {
+  dayjs.extend(utc)
   const date = useRecoilValue(CoffeeChatStartDate)
   const targetDay = dayjs(date + "")
     .add(addNum, "day")
     .format("YYYY년MM월DD일")
   const targetList = useRecoilValue(ScheduleListAtomFamily(targetDay))
-  return targetList.schedule.map(
-    (time) =>
-      `${dayjs(date + "")
-        .add(addNum, "day")
-        .format("YYYY-MM-DD")}T${time}:00`,
-  )
+  return targetList.schedule.map((time) => {
+    const DAY = dayjs(date + "")
+      .add(addNum, "day")
+      .format("YYYY-MM-DD")
+    const dateTimeStr = `${DAY} ${time}`
+    return `${dayjs(dateTimeStr).add(addNum, "day").utc().format()}`
+  })
 }
 
 export const useSetScheduleList = (addNum: number) => {


### PR DESCRIPTION
## 관련 이슈

- close: [#109 ](https://github.com/KernelSquare/Frontend/issues/109)
- 슬랙에서 언급된 UTC 변환 이슈

## 개요

> 정책에 맞추어 예약 생성 시 캘린더 화면에 표시되도록 수정하였습니다.
> 예약 생성 시 선택 날짜를 UTC 기준으로 변환하여 보낼 수 있도록 처리하였습니다.

![image](https://github.com/KernelSquare/Frontend/assets/123251211/4e533c1b-52a1-4d6a-8527-74722498134b)

- 2월 15일 오전 6시/8시/10시/10시 반/4시 반 선택 기준
