### PR TITLE
fix: 마크다운 Viewer 절대경로로 수정 

### DIFF
--- a/src/mocks/db/coffee-chat.ts
+++ b/src/mocks/db/coffee-chat.ts
@@ -11,7 +11,7 @@ export const mockCoffeeChatReservations: Array<MockCoffeechat> = [
   {
     article_id: 1,
     title: "홍주광의 알고리즘 특강",
-    content: "콘텐츠 1",
+    content: "[네이버](www.naver.com)",
     member_id: mockUsers[1].id,
     member_image_url: mockUsers[1].image_url!,
     nickname: mockUsers[1].nickname,

--- a/src/page/coffee-chat/detail/CoffeeChatDetailContent.tsx
+++ b/src/page/coffee-chat/detail/CoffeeChatDetailContent.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { handleViewerLink } from "@/util/editor"
 import dynamic from "next/dynamic"
 
 interface CoffeeChatDetailContentProps {
@@ -15,7 +16,10 @@ const MdViewer = dynamic(
 
 function CoffeeChatDetailContent({ content }: CoffeeChatDetailContentProps) {
   return (
-    <div className="min-h-[200px] border border-colorsGray rounded-lg p-2">
+    <div
+      className="min-h-[200px] border border-colorsGray rounded-lg p-2"
+      onClick={(e) => handleViewerLink("chat")(e)}
+    >
       <MdViewer content={content} />
     </div>
   )

--- a/src/page/qna-detail/components/Markdown/MdViewer.tsx
+++ b/src/page/qna-detail/components/Markdown/MdViewer.tsx
@@ -5,6 +5,7 @@ import "prismjs/themes/prism.css"
 import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css"
 import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js"
 import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js"
+import { handleViewerLink } from "@/util/editor"
 
 export interface ViewerProps {
   content: string
@@ -16,29 +17,7 @@ const MdViewer: React.FC<ViewerProps> = ({ content }) => {
       {content && (
         <div
           className="[&_.toastui-editor-contents]:text-[20px]"
-          onClick={(e) => {
-            if ((e.target as HTMLElement).tagName !== "A") return
-
-            const target = e.target as HTMLAnchorElement
-
-            if (
-              !target.href.startsWith("http://") ||
-              !target.href.startsWith("https://")
-            ) {
-              e.preventDefault()
-
-              const origin = `${window.location.origin}/question`
-
-              const targetURL = target.href.replace(`${origin}/`, "")
-              const newLink = `https://${targetURL}`
-
-              const linkElement = document.createElement("a")
-              linkElement.href = newLink
-              linkElement.target = "_blank"
-
-              linkElement.click()
-            }
-          }}
+          onClick={(e) => handleViewerLink("question")(e)}
         >
           <Viewer
             initialValue={content || " "}

--- a/src/page/qna-detail/components/Markdown/MdViewer.tsx
+++ b/src/page/qna-detail/components/Markdown/MdViewer.tsx
@@ -14,7 +14,32 @@ const MdViewer: React.FC<ViewerProps> = ({ content }) => {
   return (
     <div>
       {content && (
-        <div className="[&_.toastui-editor-contents]:text-[20px]">
+        <div
+          className="[&_.toastui-editor-contents]:text-[20px]"
+          onClick={(e) => {
+            if ((e.target as HTMLElement).tagName !== "A") return
+
+            const target = e.target as HTMLAnchorElement
+
+            if (
+              !target.href.startsWith("http://") ||
+              !target.href.startsWith("https://")
+            ) {
+              e.preventDefault()
+
+              const origin = `${window.location.origin}/question`
+
+              const targetURL = target.href.replace(`${origin}/`, "")
+              const newLink = `https://${targetURL}`
+
+              const linkElement = document.createElement("a")
+              linkElement.href = newLink
+              linkElement.target = "_blank"
+
+              linkElement.click()
+            }
+          }}
+        >
           <Viewer
             initialValue={content || " "}
             /*@ts-ignore*/

--- a/src/page/user-profile/components/introduction/MdViewer.tsx
+++ b/src/page/user-profile/components/introduction/MdViewer.tsx
@@ -5,6 +5,7 @@ import "prismjs/themes/prism.css"
 import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight.css"
 import "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js"
 import codeSyntaxHighlight from "@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js"
+import { handleViewerLink } from "@/util/editor"
 
 export interface ViewerProps {
   content: string
@@ -14,7 +15,10 @@ const MdViewer: React.FC<ViewerProps> = ({ content }) => {
   return (
     <div>
       {content && (
-        <div className="[&_.toastui-editor-contents]:text-[16px]">
+        <div
+          className="[&_.toastui-editor-contents]:text-[16px]"
+          onClick={(e) => handleViewerLink("profile")(e)}
+        >
           <Viewer
             initialValue={content || " "}
             /*@ts-ignore*/

--- a/src/util/editor.ts
+++ b/src/util/editor.ts
@@ -47,3 +47,28 @@ function getMockImageIdFromLink(mockImageUrl: string) {
 
   return imageIdResultArray[0]
 }
+
+export const handleViewerLink =
+  (domain: string) => (e: React.MouseEvent<HTMLDivElement>) => {
+    if ((e.target as HTMLElement).tagName !== "A") return
+
+    const target = e.target as HTMLAnchorElement
+
+    if (
+      !target.href.startsWith("http://") ||
+      !target.href.startsWith("https://")
+    ) {
+      e.preventDefault()
+
+      const origin = `${window.location.origin}/${domain}`
+
+      const targetURL = target.href.replace(`${origin}/`, "")
+      const newLink = `https://${targetURL}`
+
+      const linkElement = document.createElement("a")
+      linkElement.href = newLink
+      linkElement.target = "_blank"
+
+      linkElement.click()
+    }
+  }


### PR DESCRIPTION
## 관련 이슈

close: [#101 ](https://github.com/KernelSquare/Frontend/issues/101)

## 개요

> 기존 Toast UI Viewer에서 링크 삽입 시 상대경로로 연결되던 것을 절대경로로 연결되도록 수정하였습니다.
