### PR TITLE
refactor: API 수정 사항 및 데이터 제한 정책 반영

### DIFF
--- a/src/constants/limitation.ts
+++ b/src/constants/limitation.ts
@@ -2,6 +2,7 @@ const Limitation = {
   hashtags_cnt: 10,
   hashtags_word: 10,
   mentoring_time: 10,
+  image_size: 3 * 1024 * 1024,
 } as const
 
 export default Limitation

--- a/src/constants/limitation.ts
+++ b/src/constants/limitation.ts
@@ -3,6 +3,10 @@ const Limitation = {
   hashtags_word: 10,
   mentoring_time: 10,
   image_size: 3 * 1024 * 1024,
+  title_limit_under: 5,
+  content_limit_under: 10,
+  introduction_limit_under: 10,
+  introduction_limit_over: 1000,
 } as const
 
 export default Limitation

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -2,9 +2,11 @@ import Limitation from "./limitation"
 
 export const errorMessage = {
   notitle: "제목을 작성해주세요",
+  underTitleLimit: `제목은 최소 ${Limitation.title_limit_under}자 이상이어야 합니다.`,
   noContent: "본문 내용을 작성해주세요",
-  introductionLimitOver: "최대 1,000자까지 입력 가능합니다.",
-  introductionLimitUnder: "최소 10자 이상 입력해야 합니다.",
+  underContentLimit: `본문 내용은 최소 ${Limitation.content_limit_under}자 이상이어야 합니다.`,
+  introductionLimitOver: `최대 ${Limitation.introduction_limit_over}자까지 입력 가능합니다.`,
+  introductionLimitUnder: `최소 ${Limitation.introduction_limit_under}자 이상 입력해야 합니다.`,
   imageLimitOver: "3MB 이하의 이미지만 업로드할 수 있습니다.",
   imageUploadLimit: "이미지 파일 업로드는 1장만 가능합니다",
   invalidImageExtension: "올바른 형식의 이미지가 아닙니다.",

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -13,6 +13,9 @@ export const errorMessage = {
     "이미지 업로드 중 오류가 발생하였습니다. 다시 시도해주세요.",
   failToResetImage:
     "이미지 초기화 중 오류가 발생하였습니다. 다시 시도해주세요.",
+  failToUploadIntroduction:
+    "자기소개글 수정 중 오류가 발생하였습니다. 다시 시도해주세요.",
+  failToVote: "투표 진행 중 오류가 발생하였습니다. 다시 시도해주세요.",
   emptyCookie: "쿠키가 비어있습니다.",
   deleteAnswer: "답변 삭제 중 오류가 발생하였습니다.",
   deleteQuestion: "질문 삭제 중 오류가 발생하였습니다.",

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -3,7 +3,8 @@ import Limitation from "./limitation"
 export const errorMessage = {
   notitle: "제목을 작성해주세요",
   noContent: "본문 내용을 작성해주세요",
-  introductionLimit: "최대 300자까지 입력 가능합니다.",
+  introductionLimitOver: "최대 1,000자까지 입력 가능합니다.",
+  introductionLimitUnder: "최소 10자 이상 입력해야 합니다.",
   imageUploadLimit: "이미지 파일 업로드는 1장만 가능합니다",
   unauthorized: "로그인 후 다시 이용해주세요",
   failToUploadImage:

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -5,7 +5,9 @@ export const errorMessage = {
   noContent: "본문 내용을 작성해주세요",
   introductionLimitOver: "최대 1,000자까지 입력 가능합니다.",
   introductionLimitUnder: "최소 10자 이상 입력해야 합니다.",
+  imageLimitOver: "3MB 이하의 이미지만 업로드할 수 있습니다.",
   imageUploadLimit: "이미지 파일 업로드는 1장만 가능합니다",
+  invalidImageExtension: "올바른 형식의 이미지가 아닙니다.",
   unauthorized: "로그인 후 다시 이용해주세요",
   failToUploadImage:
     "이미지 업로드 중 오류가 발생하였습니다. 다시 시도해주세요.",

--- a/src/constants/response/answer.ts
+++ b/src/constants/response/answer.ts
@@ -66,7 +66,7 @@ export const AnswerApiStatus = {
      * 답변을 입력할 권한이 없는 회원
      */
     Forbidden: {
-      Code: 2200,
+      Code: -1,
       HttpStatus: HttpStatusCode.Forbidden,
     },
     /**
@@ -88,9 +88,10 @@ export const AnswerApiStatus = {
     /**
      * (답변 생성) 잘못된 요청
      * - 커스텀 코드가 없어서 현재는 code를 -1로 설정함
+     * - 본인 질문글에 답변 불가
      */
     BadRequest: {
-      Code: -1,
+      Code: 2202,
       HttpStatus: HttpStatusCode.BadRequest,
     },
     /**
@@ -255,6 +256,13 @@ export const AnswerApiStatus = {
     InternalServerError: {
       Code: -1,
       HttpStatus: HttpStatusCode.InternalServerError,
+    },
+    /**
+     * (투표 생성) 중복 투표 에러
+     */
+    Conflict: {
+      Code: 2602,
+      HttpStatus: HttpStatusCode.Conflict,
     },
   },
   /**

--- a/src/constants/response/image.ts
+++ b/src/constants/response/image.ts
@@ -1,5 +1,11 @@
 import { HttpStatusCode } from "axios"
-import { ApiStatus } from "./api"
+import { ApiStatus, Status } from "./api"
+
+type ImageExpandStatusType = {
+  BadExtension?: Status
+  SizeOverflow?: Status
+  InvalidCategory?: Status
+}
 
 export const ImageApiStatus = {
   /**
@@ -34,6 +40,27 @@ export const ImageApiStatus = {
     InternalServerError: {
       Code: 2401,
       HttpStatus: HttpStatusCode.InternalServerError,
+    },
+    /**
+     * (이미지 업로드) 유효하지 않는 파일 확장자
+     */
+    BadExtension: {
+      Code: 2402,
+      HttpStatus: HttpStatusCode.BadRequest,
+    },
+    /**
+     * (이미지 업로드) 파일 크기 초과
+     */
+    SizeOverflow: {
+      Code: 2403,
+      HttpStatus: HttpStatusCode.BadRequest,
+    },
+    /**
+     * (이미지 업로드) 유효하지 않은 카테고리
+     */
+    InvalidCategory: {
+      Code: 2410,
+      HttpStatus: HttpStatusCode.BadRequest,
     },
   },
   /**
@@ -88,4 +115,4 @@ export const ImageApiStatus = {
       HttpStatus: HttpStatusCode.InternalServerError,
     },
   },
-} satisfies Record<string, ApiStatus>
+} satisfies Record<string, ApiStatus & ImageExpandStatusType>

--- a/src/page/coffee-chat/create/CreateCoffeeChatReservationPage.tsx
+++ b/src/page/coffee-chat/create/CreateCoffeeChatReservationPage.tsx
@@ -27,6 +27,7 @@ import { errorMessage } from "@/constants/message"
 import dynamic from "next/dynamic"
 import { TimeCount } from "@/recoil/atoms/coffee-chat/schedule"
 import { useGetScheduleList } from "./hooks/useGetScheduleList"
+import Limitation from "@/constants/limitation"
 
 const MdEditor = dynamic(() => import("./components/MdEditor"), {
   ssr: false,
@@ -70,13 +71,17 @@ function CreateCoffeeChatReservationPage({
         toastId: "unauthorizedToCreateCoffeeChat",
         position: "top-center",
       })
-    if (!data.title)
-      return toast.error(errorMessage.notitle, {
+    if (data.title.length < Limitation.title_limit_under)
+      return toast.error(errorMessage.underTitleLimit, {
         toastId: "emptyCoffeeChatTitle",
         position: "top-center",
       })
-    if (!editorRef.current?.getInstance().getMarkdown())
-      return toast.error(errorMessage.noContent, {
+    if (
+      !editorRef.current?.getInstance().getMarkdown() ||
+      editorRef.current?.getInstance().getMarkdown().length <
+        Limitation.content_limit_under
+    )
+      return toast.error(errorMessage.underContentLimit, {
         toastId: "emptyCoffeeChatContent",
         position: "top-center",
       })

--- a/src/page/coffee-chat/create/CreateCoffeeChatReservationPage.tsx
+++ b/src/page/coffee-chat/create/CreateCoffeeChatReservationPage.tsx
@@ -36,6 +36,7 @@ function CreateCoffeeChatReservationPage({
   initialValues,
   post_id,
 }: CoffeeChatFormProps) {
+  // 추후 커피챗 게시글 수정 기능 구현 시 사용 예정
   const editMode: EditMode = initialValues && post_id ? "update" : "create"
   const [hash_tags, setHash_tags] = useRecoilState(HashTagList)
   const queryClient = useQueryClient()
@@ -65,13 +66,23 @@ function CreateCoffeeChatReservationPage({
 
   const onSubmit = async (data: CoffeeChatFormData) => {
     if (!user)
-      return toast.error(errorMessage.unauthorized, { position: "top-center" })
+      return toast.error(errorMessage.unauthorized, {
+        toastId: "unauthorizedToCreateCoffeeChat",
+        position: "top-center",
+      })
     if (!data.title)
-      return toast.error(errorMessage.notitle, { position: "top-center" })
+      return toast.error(errorMessage.notitle, {
+        toastId: "emptyCoffeeChatTitle",
+        position: "top-center",
+      })
     if (!editorRef.current?.getInstance().getMarkdown())
-      return toast.error(errorMessage.noContent, { position: "top-center" })
+      return toast.error(errorMessage.noContent, {
+        toastId: "emptyCoffeeChatContent",
+        position: "top-center",
+      })
     if (timeCount === 0)
       return toast.error(errorMessage.undertimeCntLimit, {
+        toastId: "emptyCoffeeChatTime",
         position: "top-center",
       })
     createCoffeeChatPost(
@@ -87,11 +98,10 @@ function CreateCoffeeChatReservationPage({
           queryClient.invalidateQueries({
             queryKey: ["chat"],
           })
-          setTimeout(() => {
-            replace(`/chat/${res.data.data?.reservation_article_id}`)
 
-            setHash_tags([])
-          }, 0)
+          replace(`/chat/${res.data.data?.reservation_article_id}`)
+
+          setHash_tags([])
         },
       },
     )
@@ -99,16 +109,15 @@ function CreateCoffeeChatReservationPage({
 
   const onInvalid = async (errors: FieldErrors<CoffeeChatFormData>) => {
     if (errors.title?.type === "required") {
-      toast.error("제목을 입력해주세요", { position: "top-center" })
+      toast.error(errorMessage.notitle, {
+        toastId: "emptyCoffeeChatTitle",
+        position: "top-center",
+      })
 
       window.scroll({
         top: 0,
         behavior: "smooth",
       })
-
-      setTimeout(() => {
-        setFocus("title")
-      }, 0)
 
       return
     }
@@ -168,26 +177,3 @@ function CreateCoffeeChatReservationPage({
 }
 
 export default CreateCoffeeChatReservationPage
-
-function Loading() {
-  return (
-    <div className="fixed left-0 top-[calc(var(--height-header)+67px)] sm:top-[--height-header] w-full h-full bg-white/60 backdrop-blur-[1px] flex justify-center items-center box-border p-1">
-      <h3 className="absolute w-full top-6 flex justify-center items-center">
-        <span className="inline-flex align-top justify-center items-center w-max break-all text-sm box-border px-2 py-0.5 rounded-lg border border-colorsGray bg-colorsLightGray">
-          커피챗 상세 페이지
-        </span>
-        &nbsp;를 로딩하고 있어요
-      </h3>
-      <div className="h-full">
-        <ContentLoading
-          style={{
-            width: "calc(100% - 80px)",
-            maxWidth: "400px",
-            margin: "0 auto",
-            opacity: "0.5",
-          }}
-        />
-      </div>
-    </div>
-  )
-}

--- a/src/page/coffee-chat/create/components/HashTagsSection.tsx
+++ b/src/page/coffee-chat/create/components/HashTagsSection.tsx
@@ -21,15 +21,20 @@ const HashTagsSection = () => {
   const handleAddHashTags = () => {
     // 빈 값 방지
     if (!hashtagRef.current?.value)
-      return toast.error(errorMessage.noValue, { position: "top-center" })
+      return toast.error(errorMessage.noValue, {
+        toastId: "emtpyHashtagValue",
+        position: "top-center",
+      })
     // 해시태그 개수 제한
     if (hashtags.length >= Limitation.hashtags_cnt)
       return toast.error(errorMessage.overHashtagCntLimit, {
+        toastId: "overHashtagCntLimit",
         position: "top-center",
       })
     // 해시태그 개수 제한
     if (hashtagRef.current?.value.length >= Limitation.hashtags_word)
       return toast.error(errorMessage.overHashtagWordLimit, {
+        toastId: "overHahtagWordLmit",
         position: "top-center",
       })
     // 특수문자 + 이모지 제출 방지
@@ -38,11 +43,13 @@ const HashTagsSection = () => {
       hashtagRef.current?.value.match(Regex.preventEmoji)
     )
       return toast.error(errorMessage.preventSpecialCharacter, {
+        toastId: "preventSpecialCharacter",
         position: "top-center",
       })
     // 중복 제출 방지
     if (hashtags.includes(hashtagRef.current.value))
       return toast.error(errorMessage.preventDuplicateValue, {
+        toastId: "preventDuplicateValue",
         position: "top-center",
       })
     setHashtags([...hashtags, hashtagRef.current?.value])

--- a/src/page/coffee-chat/create/components/TimeOptions.tsx
+++ b/src/page/coffee-chat/create/components/TimeOptions.tsx
@@ -27,6 +27,7 @@ const TimeOptions = ({ date }: TimeOptionsProps) => {
     } else {
       if (timeCount === Limitation.mentoring_time)
         return toast.error(errorMessage.overtimeCntLimit, {
+          toastId: "overTimeCntLimit",
           position: "top-center",
         })
       setSchedulelist({ schedule: [...schedulelist.schedule, time] })

--- a/src/page/coffee-chat/detail/reservation/mentee/TimeOptions.tsx
+++ b/src/page/coffee-chat/detail/reservation/mentee/TimeOptions.tsx
@@ -1,14 +1,9 @@
 "use client"
 
-import { useRecoilState } from "recoil"
-import { ScheduleListAtomFamily } from "@/recoil/atoms/coffee-chat/schedule"
 import { twJoin } from "tailwind-merge"
 import Button from "@/components/shared/button/Button"
 import { getDate, getHour, getTime } from "@/util/getDate"
-import {
-  CoffeeChatReservationDetailPayload,
-  CoffeeChatReservationTime,
-} from "@/interfaces/dto/coffee-chat/coffeechat-reservation-detail.dto"
+import { CoffeeChatReservationTime } from "@/interfaces/dto/coffee-chat/coffeechat-reservation-detail.dto"
 import { toast } from "react-toastify"
 import {
   errorMessage,
@@ -77,6 +72,7 @@ const TimeOptions = ({ reservation, cate, date }: TimeOptionsProps) => {
   ) => {
     if (!user)
       return toast.error(errorMessage.unauthorized, {
+        toastId: "unauthorizedToRegister",
         position: "top-center",
       })
     if (isAlreadyReservedByMe && nickname === user.nickname) {
@@ -86,6 +82,7 @@ const TimeOptions = ({ reservation, cate, date }: TimeOptionsProps) => {
           {
             onSuccess: () => {
               toast.success(successMessage.deleteCoffeeChatReservation, {
+                toastId: "successToDeleteReservation",
                 position: "top-center",
                 autoClose: 1000,
               })
@@ -95,6 +92,7 @@ const TimeOptions = ({ reservation, cate, date }: TimeOptionsProps) => {
             },
             onError: (res) => {
               toast.error(res.message, {
+                toastId: "failToDeleteReservation",
                 position: "top-center",
                 autoClose: 1000,
               })
@@ -105,6 +103,7 @@ const TimeOptions = ({ reservation, cate, date }: TimeOptionsProps) => {
 
       const cancleToDelete = () => {
         toast.error(notificationMessage.cancleReservation, {
+          toastId: "cancleDeleteReservation",
           position: "top-center",
         })
       }
@@ -122,11 +121,13 @@ const TimeOptions = ({ reservation, cate, date }: TimeOptionsProps) => {
 
     if (isAlreadyReservedByMe)
       return toast.error(errorMessage.youAlreadyReserved, {
+        toastId: "youAlreadyReserved",
         position: "top-center",
       })
 
     if (nickname && nickname !== user.nickname)
       return toast.error(errorMessage.alreadyReserved, {
+        toastId: "othersAlreadyReserved",
         position: "top-center",
       })
     else {
@@ -141,6 +142,7 @@ const TimeOptions = ({ reservation, cate, date }: TimeOptionsProps) => {
           {
             onSuccess: () => {
               toast.success(successMessage.reserveCoffeeChat, {
+                toastId: "successToCreateReservation",
                 position: "top-center",
                 autoClose: 1000,
               })
@@ -150,6 +152,7 @@ const TimeOptions = ({ reservation, cate, date }: TimeOptionsProps) => {
             },
             onError: (res) => {
               toast.error(res.message, {
+                toastId: "failToCreateReservation",
                 position: "top-center",
                 autoClose: 1000,
               })
@@ -160,6 +163,7 @@ const TimeOptions = ({ reservation, cate, date }: TimeOptionsProps) => {
 
       const cancleToCreate = () => {
         toast.error(notificationMessage.cancleReservation, {
+          toastId: "cancleCreateReservation",
           position: "top-center",
         })
       }

--- a/src/page/qna-detail/components/Answers/AnswerContentBox.tsx
+++ b/src/page/qna-detail/components/Answers/AnswerContentBox.tsx
@@ -40,7 +40,7 @@ const AnswerContentBox: React.FC<EditAnswerProps> = ({ answer }) => {
     answerId: Number(answer.answer_id),
     questionId: Number(answer.question_id),
   })
-  const { checkNullValue } = useQnADetail({ questionId: answer.question_id })
+  const { checkNullValue } = useQnADetail()
   const { updateAnswer } = answerQueries.useUpdateAnswer()
   const queryClient = useQueryClient()
 
@@ -53,6 +53,7 @@ const AnswerContentBox: React.FC<EditAnswerProps> = ({ answer }) => {
     const submitValue = editorRef.current?.getInstance().getMarkdown()
     if (!submitValue || checkNullValue(submitValue)) {
       toast.error(errorMessage.noContent, {
+        toastId: "emptyAnswerContent",
         position: "top-center",
         autoClose: 1000,
       })
@@ -70,6 +71,7 @@ const AnswerContentBox: React.FC<EditAnswerProps> = ({ answer }) => {
     updateAnswer(updateProps, {
       onSuccess: () => {
         toast.success(successMessage.updateAnswer, {
+          toastId: "successToUpdateAnswer",
           position: "top-center",
         })
         setIsAnswerEditMode(false)

--- a/src/page/qna-detail/components/Answers/AnswerList.tsx
+++ b/src/page/qna-detail/components/Answers/AnswerList.tsx
@@ -25,9 +25,7 @@ const AnswerList: React.FC<AnswerProps> = ({
   const { data, isPending } = answerQueries.useGetAnswers({
     questionId,
   })
-  const { filterMyAnswer, handleIsChecked } = useQnADetail({
-    questionId,
-  })
+  const { filterMyAnswer, handleIsChecked } = useQnADetail()
   const isAnswer = !!data?.data?.answer_responses.length
 
   if (isPending) return <Loading />

--- a/src/page/qna-detail/components/Answers/OneAnswer.tsx
+++ b/src/page/qna-detail/components/Answers/OneAnswer.tsx
@@ -17,7 +17,7 @@ export interface OneAnswerProps {
 }
 
 const OneAnswer: React.FC<OneAnswerProps> = ({ answer, createdby }) => {
-  const { ProgressModalView } = useQnADetail({ questionId: answer.question_id })
+  const { ProgressModalView } = useQnADetail()
   const { user } = useClientSession()
 
   return (

--- a/src/page/qna-detail/components/Answers/VoteBox.tsx
+++ b/src/page/qna-detail/components/Answers/VoteBox.tsx
@@ -27,14 +27,20 @@ const VoteBox: React.FC<VoteBoxProps> = ({ answer }) => {
 
   const handleVoteRaise = () => {
     if (answer.created_by === user?.nickname)
-      return toast.error(errorMessage.voteForMe, { position: "top-center" })
+      return toast.error(errorMessage.voteForMe, {
+        toastId: "voteForMe",
+        position: "top-center",
+      })
     if (answer.vote_status === 0) return handleRaise()
     return handleCancle()
   }
 
   const handleVoteReduce = () => {
     if (answer.created_by === user?.nickname)
-      return toast.error(errorMessage.voteForMe, { position: "top-center" })
+      return toast.error(errorMessage.voteForMe, {
+        toastId: "voteForMe",
+        position: "top-center",
+      })
     if (answer.vote_status === 0) return handleReduce()
 
     return handleCancle()

--- a/src/page/qna-detail/components/Markdown/MdEditor.tsx
+++ b/src/page/qna-detail/components/Markdown/MdEditor.tsx
@@ -57,6 +57,7 @@ const MdEditor: React.FC<EditorProps> = ({
       }
 
       toast.error(errorMessage.failToUploadImage, {
+        toastId: "failToUploadAnswerImage",
         position: "top-center",
       })
     },
@@ -64,13 +65,16 @@ const MdEditor: React.FC<EditorProps> = ({
       if (errorCase === "isMaximum") {
         toast.error(
           `이미지 파일 업로드는 최대 ${MAXIMUM_UPLOAD_IMAGE_LENGTH}장 가능합니다`,
-          { position: "top-center" },
+          { toastId: "overAnswerImageLimit", position: "top-center" },
         )
 
         return
       }
 
-      toast.error(errorMessage.failToUploadImage, { position: "top-center" })
+      toast.error(errorMessage.failToUploadImage, {
+        toastId: "failToUploadImage",
+        position: "top-center",
+      })
     },
   })
 

--- a/src/page/qna-detail/components/MyAnswer.tsx
+++ b/src/page/qna-detail/components/MyAnswer.tsx
@@ -25,7 +25,7 @@ const MdEditor = dynamic(() => import("../components/Markdown/MdEditor"), {
 const MyAnswer: React.FC<MyAnswerProps> = ({ questionId, list, nickname }) => {
   const { openModal } = useModal()
   const { user, handleSubmitValue, handleCheckAbilityToWriteAnswer } =
-    useQnADetail({ questionId })
+    useQnADetail()
 
   const { handleSubmit } = useForm()
   const editorRef = useRef<Editor>(null)

--- a/src/page/qna-detail/components/Question/HandleQuestionBox.tsx
+++ b/src/page/qna-detail/components/Question/HandleQuestionBox.tsx
@@ -12,7 +12,7 @@ export interface HandleQuestionBoxProps {
 
 const HandleQuestionBox: React.FC<HandleQuestionBoxProps> = ({ question }) => {
   const { handleEditQuestion, handleDeleteQuestion } = useHandleQuestion()
-  const { user } = useQnADetail({ questionId: question.id })
+  const { user } = useQnADetail()
 
   if (user?.nickname === question.nickname)
     return (

--- a/src/page/qna-detail/components/Question/Question.tsx
+++ b/src/page/qna-detail/components/Question/Question.tsx
@@ -17,7 +17,7 @@ const Question: React.FC<{ id: number }> = ({ id }) => {
     id: Number(id),
   })
 
-  const { user } = useQnADetail({ questionId: id })
+  const { user } = useQnADetail()
 
   const question = data?.data
 

--- a/src/page/qna-detail/hooks/useAnswerVote.tsx
+++ b/src/page/qna-detail/hooks/useAnswerVote.tsx
@@ -51,10 +51,14 @@ const useAnswerVote = ({ answer }: VoteProps) => {
 
   const handleRaise = async () => {
     if (!user)
-      return toast.error(errorMessage.unauthorized, { position: "top-center" })
+      return toast.error(errorMessage.unauthorized, {
+        toastId: "upauthorizedToVote",
+        position: "top-center",
+      })
     try {
       if (voteAnswerStatus.isVoteAnswer)
         return toast.error(pendingMessage.votePending, {
+          toastId: "votePending",
           position: "top-center",
         })
       voteAnswer(
@@ -70,16 +74,24 @@ const useAnswerVote = ({ answer }: VoteProps) => {
         },
       )
     } catch (err) {
+      toast.error(errorMessage.failToVote, {
+        toastId: "failToVote",
+        position: "top-center",
+      })
       throw new Error("투표 진행 중 오류가 발생했습니다.")
     }
   }
 
   const handleReduce = async () => {
     if (!user)
-      return toast.error(errorMessage.unauthorized, { position: "top-center" })
+      return toast.error(errorMessage.unauthorized, {
+        toastId: "upauthorizedToVote",
+        position: "top-center",
+      })
     try {
       if (voteAnswerStatus.isVoteAnswer)
         return toast.error(pendingMessage.votePending, {
+          toastId: "votePending",
           position: "top-center",
         })
       voteAnswer(
@@ -94,15 +106,25 @@ const useAnswerVote = ({ answer }: VoteProps) => {
         },
       )
     } catch (err) {
+      toast.error(errorMessage.failToVote, {
+        toastId: "failToVote",
+        position: "top-center",
+      })
       throw new Error("투표 진행 중 오류가 발생했습니다.")
     }
   }
 
   const handleCancle = () => {
     if (!user)
-      return toast.error(errorMessage.unauthorized, { position: "top-center" })
+      return toast.error(errorMessage.unauthorized, {
+        toastId: "upauthorizedToVote",
+        position: "top-center",
+      })
     if (deleteVoteAnswerStatus.isDeleteVoteAnswer)
-      return toast.error(pendingMessage.votePending, { position: "top-center" })
+      return toast.error(pendingMessage.votePending, {
+        toastId: "votePending",
+        position: "top-center",
+      })
     const onSuccess = async () => {
       try {
         deleteVoteAnswer(
@@ -126,11 +148,16 @@ const useAnswerVote = ({ answer }: VoteProps) => {
           },
         )
       } catch (err) {
+        toast.error(errorMessage.failToVote, {
+          toastId: "failToVote",
+          position: "top-center",
+        })
         throw new Error("투표 진행 중 오류가 발생했습니다.")
       }
     }
     const onCancel = () => {
       toast.error(notificationMessage.cancleDeleteVote, {
+        toastId: "cancleDeleteVote",
         position: "top-center",
       })
     }

--- a/src/page/qna-detail/hooks/useHandleMyAnswer.tsx
+++ b/src/page/qna-detail/hooks/useHandleMyAnswer.tsx
@@ -40,7 +40,7 @@ const useHandleMyAnswer = ({ answerId, questionId }: AnswerProps) => {
   )
   const queryClient = useQueryClient()
   const { openModal } = useModal()
-  const { checkNullValue } = useQnADetail({ questionId })
+  const { checkNullValue } = useQnADetail()
   const { deleteImage } = useDeleteImage()
   const { updateAnswer } = answerQueries.useUpdateAnswer()
   const { deleteAnswer } = answerQueries.useDeleteAnswer()
@@ -48,6 +48,7 @@ const useHandleMyAnswer = ({ answerId, questionId }: AnswerProps) => {
   const handleEditValue = ({ submitValue, answer }: EditValueProps) => {
     if (checkNullValue(submitValue)) {
       toast.error(errorMessage.noContent, {
+        toastId: "emptyAnswerContent",
         position: "top-center",
         autoClose: 1000,
       })
@@ -64,6 +65,7 @@ const useHandleMyAnswer = ({ answerId, questionId }: AnswerProps) => {
       {
         onSuccess: () => {
           toast.success(successMessage.updateAnswer, {
+            toastId: "successToUpdateAnswer",
             position: "top-center",
           })
           setIsAnswerEditMode(false)
@@ -72,15 +74,15 @@ const useHandleMyAnswer = ({ answerId, questionId }: AnswerProps) => {
           })
         },
         onError: () =>
-          toast.error(errorMessage.updateAnswer, { position: "top-center" }),
+          toast.error(errorMessage.updateAnswer, {
+            toastId: "failToUpdateAnswer",
+            position: "top-center",
+          }),
       },
     )
   }
 
-  const handleDeleteValue = async ({
-    answer,
-    successModal,
-  }: DeleteValueProps) => {
+  const handleDeleteValue = async ({ answer }: DeleteValueProps) => {
     const onSuccess = async () => {
       try {
         deleteAnswer(
@@ -90,6 +92,7 @@ const useHandleMyAnswer = ({ answerId, questionId }: AnswerProps) => {
           {
             onSuccess: () => {
               toast.success(successMessage.deleteAnswer, {
+                toastId: "successToDeleteAnswer",
                 position: "top-center",
               })
 
@@ -110,6 +113,7 @@ const useHandleMyAnswer = ({ answerId, questionId }: AnswerProps) => {
     }
     const onCancel = () => {
       toast.error(notificationMessage.cancleDeleteAnswer, {
+        toastId: "cancleDeleteAnswer",
         position: "top-center",
       })
     }

--- a/src/page/qna-detail/hooks/useHandleQuestion.tsx
+++ b/src/page/qna-detail/hooks/useHandleQuestion.tsx
@@ -8,7 +8,6 @@ import { deleteQuestion } from "@/service/question"
 import { useQueryClient } from "@tanstack/react-query"
 import { useRouter } from "next/navigation"
 import { toast } from "react-toastify"
-import Regex from "@/constants/regex"
 import { useDeleteImage } from "@/hooks/image/useDeleteImage"
 import type { ModalState } from "@/interfaces/modal"
 import type { Question } from "@/interfaces/question"
@@ -40,7 +39,7 @@ const useHandleQuestion = () => {
       try {
         const imageUrl = findImageLinkUrlFromMarkdown(question.content)
 
-        const res = await deleteQuestion({
+        deleteQuestion({
           questionId: question.id,
         })
         openModal({
@@ -66,6 +65,7 @@ const useHandleQuestion = () => {
     }
     const onCancel = () => {
       toast.error(notificationMessage.cancleDeleteQuestion, {
+        toastId: "cancleDeleteQuestion",
         position: "top-center",
       })
     }

--- a/src/page/qna-detail/hooks/useQnADetail.tsx
+++ b/src/page/qna-detail/hooks/useQnADetail.tsx
@@ -17,15 +17,13 @@ export interface SubmitValueProps {
   submitValue: string | undefined
 }
 
-type useQnADetailProps = { questionId: number }
-
-const useQnADetail = ({ questionId }: useQnADetailProps) => {
+const useQnADetail = () => {
   const { ProgressModalView, setStep } = useProgressModal()
   const { user } = useClientSession()
   const { openModal } = useModal()
   const queryClient = useQueryClient()
 
-  const { createAnswer, createAnswerStatus } = answerQueries.useCreateAnswer()
+  const { createAnswer } = answerQueries.useCreateAnswer()
 
   const checkNullValue = (submitValue: string | undefined) => {
     if (typeof submitValue === undefined) return true
@@ -69,6 +67,7 @@ const useQnADetail = ({ questionId }: useQnADetailProps) => {
   }: SubmitValueProps) => {
     if (checkNullValue(submitValue)) {
       toast.error(errorMessage.noContent, {
+        toastId: "emptyAnswerContent",
         position: "top-center",
         autoClose: 1000,
       })

--- a/src/page/user-profile/components/UserProfilePresenter.tsx
+++ b/src/page/user-profile/components/UserProfilePresenter.tsx
@@ -97,7 +97,7 @@ UserProfilePresenter.ContentWrapper = function UserProfileContentWrapper({
 }: PropsWithChildren) {
   return (
     <>
-      <div className="relative box-border px-4 z-[1] bg-white sm:flex-1">
+      <div className="w-[100px] relative box-border px-4 z-[1] bg-white sm:flex-1">
         {children}
       </div>
     </>

--- a/src/page/user-profile/components/introduction/MdViewer.tsx
+++ b/src/page/user-profile/components/introduction/MdViewer.tsx
@@ -16,7 +16,7 @@ const MdViewer: React.FC<ViewerProps> = ({ content }) => {
     <div>
       {content && (
         <div
-          className="[&_.toastui-editor-contents]:text-[16px]"
+          className="[&_.toastui-editor-contents]:text-[16px] overflow-x-hidden"
           onClick={(e) => handleViewerLink("profile")(e)}
         >
           <Viewer

--- a/src/page/user-profile/components/profileImage/ProfileImage.tsx
+++ b/src/page/user-profile/components/profileImage/ProfileImage.tsx
@@ -27,7 +27,7 @@ const ProfileImage = ({ user_id, image_url }: ProfileImageProps) => {
         type="file"
         ref={imageUploadRef}
         className="hidden"
-        accept="image/*"
+        accept=".png, .jpeg, .svg, .gif"
         onChange={(e) => handleImageChange(e, user_id)}
       />
       {isMyPage && (

--- a/src/page/user-profile/hooks/useIntroduction.tsx
+++ b/src/page/user-profile/hooks/useIntroduction.tsx
@@ -29,6 +29,7 @@ const useIntroduction = () => {
   const handleSubmitIntroduction = (introduction: string) => {
     if (!user) {
       toast.error(errorMessage.unauthorized, {
+        toastId: "unauthorizedToChangeIntroduction",
         position: "top-center",
         autoClose: 1000,
       })
@@ -36,6 +37,7 @@ const useIntroduction = () => {
     }
     if (introduction.length < 10) {
       toast.error(errorMessage.introductionLimitUnder, {
+        toastId: "introductionLimitUnder",
         position: "top-center",
         autoClose: 1000,
       })
@@ -43,6 +45,7 @@ const useIntroduction = () => {
     }
     if (introduction.length > 1000) {
       toast.error(errorMessage.introductionLimitOver, {
+        toastId: "introductionLimitOver",
         position: "top-center",
         autoClose: 1000,
       })
@@ -58,6 +61,7 @@ const useIntroduction = () => {
         {
           onSuccess: () => {
             toast.success(successMessage.editIntroduction, {
+              toastId: "successToEditIntroduction",
               position: "top-center",
               autoClose: 1000,
             })
@@ -69,12 +73,18 @@ const useIntroduction = () => {
         },
       )
     } catch (err) {
+      toast.error(errorMessage.failToUploadIntroduction, {
+        toastId: "failToEditIntroduction",
+        position: "top-center",
+        autoClose: 1000,
+      })
       throw new Error("자기소개 업데이트 중 에러가 발생하였습니다.")
     }
   }
 
   const handleCancleEditIntroduction = () =>
     toast.error(notificationMessage.cancleEditIntroduction, {
+      toastId: "cancleEditIntroduction",
       position: "top-center",
     })
 

--- a/src/page/user-profile/hooks/useIntroduction.tsx
+++ b/src/page/user-profile/hooks/useIntroduction.tsx
@@ -34,6 +34,20 @@ const useIntroduction = () => {
       })
       return
     }
+    if (introduction.length < 10) {
+      toast.error(errorMessage.introductionLimitUnder, {
+        position: "top-center",
+        autoClose: 1000,
+      })
+      return
+    }
+    if (introduction.length > 1000) {
+      toast.error(errorMessage.introductionLimitOver, {
+        position: "top-center",
+        autoClose: 1000,
+      })
+      return
+    }
 
     try {
       updateMemberIntroduction(

--- a/src/page/user-profile/hooks/useProfileImage.tsx
+++ b/src/page/user-profile/hooks/useProfileImage.tsx
@@ -12,6 +12,7 @@ import { toast } from "react-toastify"
 import queryKey from "@/constants/queryKey"
 import { useQueryClient } from "@tanstack/react-query"
 import { memberQueries } from "@/react-query/member"
+import Limitation from "@/constants/limitation"
 
 export interface SaveImageProps {
   image: File
@@ -92,6 +93,30 @@ const useProfileImage = (image_url: string | null) => {
   ) => {
     if (event.target.files) {
       const file = event.target.files[0]
+      console.log("image size", file.size, file.size > Limitation.image_size)
+
+      // 파일 용량 제한
+      if (file.size > Limitation.image_size) {
+        toast.error(errorMessage.imageLimitOver, {
+          position: "top-center",
+          autoClose: 1000,
+        })
+        return
+      }
+
+      // 파일 확장자 제한
+      if (
+        !file.type.includes("png") ||
+        !file.type.includes("svg") ||
+        !file.type.includes("jpeg") ||
+        !file.type.includes("gif")
+      ) {
+        toast.error(errorMessage.invalidImageExtension, {
+          position: "top-center",
+          autoClose: 1000,
+        })
+        return
+      }
 
       setPreview((prevPreview) => {
         if (prevPreview) {

--- a/src/page/user-profile/hooks/useProfileImage.tsx
+++ b/src/page/user-profile/hooks/useProfileImage.tsx
@@ -13,6 +13,7 @@ import queryKey from "@/constants/queryKey"
 import { useQueryClient } from "@tanstack/react-query"
 import { memberQueries } from "@/react-query/member"
 import Limitation from "@/constants/limitation"
+import { useDeleteImage } from "@/hooks/image/useDeleteImage"
 
 export interface SaveImageProps {
   image: File
@@ -24,6 +25,7 @@ export interface ResetImageProps {}
 const useProfileImage = (image_url: string | null) => {
   const { user, clientSessionUpdate } = useClientSession()
   const { openModal } = useModal()
+  const { deleteImage } = useDeleteImage()
   const [image, setImage] = useState<string | ArrayBuffer | null>(image_url)
   const [preview, setPreview] = useState<string>("")
   const queryClient = useQueryClient()
@@ -46,6 +48,7 @@ const useProfileImage = (image_url: string | null) => {
             onSuccess: () => {
               toast.success(successMessage.editProfileImage, {
                 position: "top-center",
+                toastId: "successToUploadProfileImage",
               })
               clientSessionUpdate({
                 image_url: imageUploadResponse.data.data?.image_url,
@@ -65,6 +68,7 @@ const useProfileImage = (image_url: string | null) => {
       } catch (error) {
         toast.error(errorMessage.failToUploadImage, {
           position: "top-center",
+          toastId: "failToUploadProfileImage",
         })
       }
     }
@@ -72,6 +76,7 @@ const useProfileImage = (image_url: string | null) => {
     const onCancel = () => {
       toast.error(notificationMessage.cancleUploadImage, {
         position: "top-center",
+        toastId: "cancleUploadProfileImage",
       })
     }
 
@@ -99,6 +104,7 @@ const useProfileImage = (image_url: string | null) => {
       if (file.size > Limitation.image_size) {
         toast.error(errorMessage.imageLimitOver, {
           position: "top-center",
+          toastId: "profileImageLimitOver",
           autoClose: 1000,
         })
         return
@@ -113,6 +119,7 @@ const useProfileImage = (image_url: string | null) => {
       ) {
         toast.error(errorMessage.invalidImageExtension, {
           position: "top-center",
+          toastId: "invalidImageExtension",
           autoClose: 1000,
         })
         return
@@ -144,6 +151,7 @@ const useProfileImage = (image_url: string | null) => {
 
   const handleResetImage = async (memberId: number) => {
     const onSuccess = async () => {
+      const previousImage = image_url
       try {
         updateMemberProfileImage(
           {
@@ -152,8 +160,10 @@ const useProfileImage = (image_url: string | null) => {
           },
           {
             onSuccess: () => {
+              if (previousImage) deleteImage(previousImage)
               toast.success(successMessage.editResetProfileImage, {
                 position: "top-center",
+                toastId: "successToResetProfileImage",
               })
               clientSessionUpdate({
                 image_url: null,
@@ -173,6 +183,7 @@ const useProfileImage = (image_url: string | null) => {
       } catch (error) {
         toast.error(errorMessage.failToResetImage, {
           position: "top-center",
+          toastId: "failToResetProfileImage",
         })
         console.error("Error", error)
       }
@@ -181,6 +192,7 @@ const useProfileImage = (image_url: string | null) => {
     const onCancel = () => {
       toast.error(notificationMessage.cancleResetImage, {
         position: "top-center",
+        toastId: "cancleResetProfileImage",
       })
     }
 


### PR DESCRIPTION
## 관련 이슈

close: [#169 ](https://github.com/KernelSquare/Frontend/issues/169)

## 개요

> API 수정 사항 및 데이터 제한 정책을 반영하였습니다.

## 상세 내용

- 답변 상세 등 응답 코드 수정된 부분 반영하였습니다.
- 마이페이지 및 커피챗 게시글 생성 페이지 글자수 상항 제한 정책을 반영하여 미만/초과 시 제출 불가능하도록 유효성 검사 로직을 추가하였습니다.
- 마이페이지 프로필 이미지 확장자 및 규격 제한 정책을 반영하여 3MB를 초과하거나 유효하지 않은 확장자의 파일을 제출할 경우 반영되지 않도록 수정하였습니다.
- 프로필 이미지 초기화 시 이미지 저장소에서 해당 파일이 삭제되지 않던 오류를 수정하였습니다.
- react-toastify를 사용한 알림이 중복 렌더링 되는 것을 방지하기 위해 기존에 toast 객체를 사용한 부분에 `toastId` 속성을 추가해주었습니다. 
