### PR TITLE
fix: 질문 작성 및 수정 제한 적용

### DIFF
--- a/src/constants/limitation.ts
+++ b/src/constants/limitation.ts
@@ -28,7 +28,6 @@ const Limitation = {
   hashtags_cnt: 10,
   hashtags_word: 10,
   mentoring_time: 10,
-  image_size: 3 * 1024 * 1024,
   title_limit_under: 5,
   question_title_limit_over: 100,
   content_limit_under: 10,
@@ -37,7 +36,7 @@ const Limitation = {
   introduction_limit_over: 1000,
   image: {
     size: LimitationImage.getSize(),
-    stringifyedValue: LimitationImage.toString(),
+    stringifyedSize: LimitationImage.toString(),
     extension: {
       toString() {
         return LimitationImage.extensions
@@ -49,6 +48,9 @@ const Limitation = {
       isValidExtendsion(extension: string) {
         return LimitationImage.isValidExtension(extension)
       },
+    },
+    upload: {
+      maxLength: 1,
     },
   },
 } as const

--- a/src/constants/limitation.ts
+++ b/src/constants/limitation.ts
@@ -1,12 +1,56 @@
+type ImageSizeUnit = "KB" | "MB"
+
+const LimitationImage = {
+  value: 3,
+  sizeUnit: "MB" as ImageSizeUnit,
+  extensions: ["image/jpeg", "image/png", "image/svg+xml", "image/gif"],
+  toString() {
+    return `${this.value}${this.sizeUnit}`
+  },
+  getSize() {
+    return this.value * this.convertUnitToSize(this.sizeUnit)
+  },
+  isValidExtension(extension: string) {
+    return this.extensions.includes(extension)
+  },
+  convertUnitToSize(sizeUnit: ImageSizeUnit) {
+    const baseSize = 1024
+    const powCount = {
+      KB: 1,
+      MB: 2,
+    } satisfies Record<ImageSizeUnit, number>
+
+    return Math.pow(baseSize, powCount[sizeUnit])
+  },
+}
+
 const Limitation = {
   hashtags_cnt: 10,
   hashtags_word: 10,
   mentoring_time: 10,
   image_size: 3 * 1024 * 1024,
   title_limit_under: 5,
+  question_title_limit_over: 100,
   content_limit_under: 10,
+  question_content_limit_over: 10000,
   introduction_limit_under: 10,
   introduction_limit_over: 1000,
+  image: {
+    size: LimitationImage.getSize(),
+    stringifyedValue: LimitationImage.toString(),
+    extension: {
+      toString() {
+        return LimitationImage.extensions
+          .map((imageType) =>
+            imageType.replace("image/", "").replace("+xml", ""),
+          )
+          .join(", ")
+      },
+      isValidExtendsion(extension: string) {
+        return LimitationImage.isValidExtension(extension)
+      },
+    },
+  },
 } as const
 
 export default Limitation

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -3,13 +3,19 @@ import Limitation from "./limitation"
 export const errorMessage = {
   notitle: "제목을 작성해주세요",
   underTitleLimit: `제목은 최소 ${Limitation.title_limit_under}자 이상이어야 합니다.`,
+  questionOverTitleLimit: `제목은 최대 ${Limitation.question_title_limit_over}자 이하이어야 합니다.`,
   noContent: "본문 내용을 작성해주세요",
   underContentLimit: `본문 내용은 최소 ${Limitation.content_limit_under}자 이상이어야 합니다.`,
+  questionContentOverLimit: `본문 내용은 최대 ${Limitation.question_content_limit_over}자 이하이어야 합니다.`,
   introductionLimitOver: `최대 ${Limitation.introduction_limit_over}자까지 입력 가능합니다.`,
   introductionLimitUnder: `최소 ${Limitation.introduction_limit_under}자 이상 입력해야 합니다.`,
-  imageLimitOver: "3MB 이하의 이미지만 업로드할 수 있습니다.",
-  imageUploadLimit: "이미지 파일 업로드는 1장만 가능합니다",
+  imageLimitOver: `${Limitation.image.stringifyedSize} 이하의 이미지만 업로드할 수 있습니다.`,
+  imageUploadLimit:
+    Limitation.image.upload.maxLength === 1
+      ? "이미지 파일 업로드는 1장만 가능합니다"
+      : `이미지 파일 업로드는 최대${Limitation.image.upload.maxLength}장까지 가능합니다.`,
   invalidImageExtension: "올바른 형식의 이미지가 아닙니다.",
+  notAllowedImageExtensions: `이미지 파일 업로드는 ${Limitation.image.extension.toString()} 확장자만 가능합니다`,
   unauthorized: "로그인 후 다시 이용해주세요",
   failToUploadImage:
     "이미지 업로드 중 오류가 발생하였습니다. 다시 시도해주세요.",

--- a/src/hooks/useToastUiEditorImageUploadHook.tsx
+++ b/src/hooks/useToastUiEditorImageUploadHook.tsx
@@ -7,8 +7,7 @@ import { questionEditorAtomFamily } from "@/recoil/atoms/questionEditor"
 import type { HookCallback } from "@/components/shared/toast-ui-editor/editor/EditorWrapper"
 import type { APIResponse } from "@/interfaces/dto/api-response"
 import type { UploadImagesCategory } from "@/interfaces/dto/upload/upload-images.dto"
-
-type ImageSizeUnit = "MB"
+import Limitation from "@/constants/limitation"
 
 type SuccessCallbackArg = {
   file: File
@@ -61,26 +60,6 @@ export const notAllowedUploadableExtension = new Error(
 )
 
 export const MAXIMUM_UPLOAD_IMAGE_LENGTH = 1
-export const MAXIMUN_UPLOAD_IMAGE_SIZE = {
-  target: [3, "MB"] as [number, ImageSizeUnit],
-  toString() {
-    return this.target.join("")
-  },
-  get value() {
-    const [size, unit] = this.target
-
-    switch (unit) {
-      case "MB":
-        return size * 1024 * 1024
-    }
-  },
-}
-export const ALLOW_IMAGE_TYPES = [
-  "image/jpeg",
-  "image/png",
-  "image/svg+xml",
-  "image/gif",
-]
 
 export function useToastUiEditorImageUploadHook({
   atomKey,
@@ -144,11 +123,14 @@ export function useToastUiEditorImageUploadHook({
         throw exceedingUploadableImagesError
       }
 
-      if ((blob as File)?.size && blob.size > MAXIMUN_UPLOAD_IMAGE_SIZE.value) {
+      if ((blob as File)?.size && blob.size > Limitation.image.size) {
         throw exceedingUploadableImageSizeError
       }
 
-      if ((blob as File)?.type && !ALLOW_IMAGE_TYPES.includes(blob.type)) {
+      if (
+        (blob as File)?.type &&
+        !Limitation.image.extension.isValidExtendsion(blob.type)
+      ) {
         throw notAllowedUploadableExtension
       }
 

--- a/src/hooks/useToastUiEditorImageUploadHook.tsx
+++ b/src/hooks/useToastUiEditorImageUploadHook.tsx
@@ -59,13 +59,11 @@ export const notAllowedUploadableExtension = new Error(
   { cause: "not allowed file extension" },
 )
 
-export const MAXIMUM_UPLOAD_IMAGE_LENGTH = 1
-
 export function useToastUiEditorImageUploadHook({
   atomKey,
   category,
   action,
-  maximumUploadImageLength = MAXIMUM_UPLOAD_IMAGE_LENGTH,
+  maximumUploadImageLength = Limitation.image.upload.maxLength,
   onUploadSuccess,
   onUploadError,
   onError,

--- a/src/page/askQuestion/components/AskQuestionForm.tsx
+++ b/src/page/askQuestion/components/AskQuestionForm.tsx
@@ -31,10 +31,7 @@ import { revalidatePage } from "@/util/actions/revalidatePage"
 import { replaceAllMarkdownImageLink } from "@/util/editor"
 import { useDeleteImage } from "@/hooks/image/useDeleteImage"
 import { useToastUiQuestionEditor } from "@/hooks/editor/useToastuiQuestionEditor"
-import {
-  MAXIMUM_UPLOAD_IMAGE_LENGTH,
-  useToastUiEditorImageUploadHook,
-} from "@/hooks/useToastUiEditorImageUploadHook"
+import { useToastUiEditorImageUploadHook } from "@/hooks/useToastUiEditorImageUploadHook"
 import { useSelectTagList } from "@/hooks/useSelectTagList"
 import type { FieldErrors } from "react-hook-form"
 import type {
@@ -45,6 +42,7 @@ import type {
 import { useResetRecoilState } from "recoil"
 import { searchTagAtom } from "@/recoil/atoms/tag"
 import Limitation from "@/constants/limitation"
+import { errorMessage } from "@/constants/message"
 
 export interface QuestionEditorInitialValues {
   title: string
@@ -149,31 +147,28 @@ function AskQuestionForm({
       },
       onError({ errorCase }) {
         if (errorCase === "isMaximum") {
-          toast.error(
-            `이미지 파일 업로드는 최대${MAXIMUM_UPLOAD_IMAGE_LENGTH}장 가능합니다`,
-            { position: "top-center", toastId: "imageLengthError" },
-          )
+          toast.error(errorMessage.imageUploadLimit, {
+            position: "top-center",
+            toastId: "imageLengthError",
+          })
 
           return
         }
 
         if (errorCase === "isMaximumSize") {
-          toast.error(
-            `이미지 파일 업로드는 최대 ${Limitation.image.stringifyedValue} 가능합니다`,
-            {
-              position: "top-center",
-              toastId: "imageSizeError",
-            },
-          )
+          toast.error(errorMessage.imageLimitOver, {
+            position: "top-center",
+            toastId: "imageSizeError",
+          })
 
           return
         }
 
         if (errorCase === "notAllowedExtension") {
-          toast.error(
-            `이미지 파일 업로드는 ${Limitation.image.extension.toString()} 확장자만 가능합니다`,
-            { position: "top-center", toastId: "imageExtensionError" },
-          )
+          toast.error(errorMessage.notAllowedImageExtensions, {
+            position: "top-center",
+            toastId: "imageExtensionError",
+          })
 
           return
         }
@@ -310,11 +305,11 @@ function AskQuestionForm({
       const titleErrorMessage = ((type: typeof errors.title.type) => {
         switch (type) {
           case "required":
-            return "제목을 입력해주세요"
+            return errorMessage.notitle
           case "minLength":
-            return `제목은 최소 ${Limitation.title_limit_under}자 이상 가능합니다`
+            return errorMessage.underTitleLimit
           case "maxLength":
-            return `제목은 최대 ${Limitation.question_title_limit_over}자까지 가능합니다`
+            return errorMessage.questionOverTitleLimit
         }
       })(errors.title.type)
 
@@ -340,11 +335,11 @@ function AskQuestionForm({
       const contentErrorMessage = ((type: typeof errors.content.type) => {
         switch (type) {
           case "required":
-            return "본문을 입력해주세요"
+            return errorMessage.noContent
           case "minLength":
-            return `본문은 최소 ${Limitation.content_limit_under}자 이상 가능합니다`
+            return errorMessage.underContentLimit
           case "maxLength":
-            return `본문은 최대 ${Limitation.question_content_limit_over}자까지 가능합니다`
+            return errorMessage.questionContentOverLimit
         }
       })(errors.content.type)
 

--- a/src/page/askQuestion/components/AskQuestionForm.tsx
+++ b/src/page/askQuestion/components/AskQuestionForm.tsx
@@ -32,9 +32,7 @@ import { replaceAllMarkdownImageLink } from "@/util/editor"
 import { useDeleteImage } from "@/hooks/image/useDeleteImage"
 import { useToastUiQuestionEditor } from "@/hooks/editor/useToastuiQuestionEditor"
 import {
-  ALLOW_IMAGE_TYPES,
   MAXIMUM_UPLOAD_IMAGE_LENGTH,
-  MAXIMUN_UPLOAD_IMAGE_SIZE,
   useToastUiEditorImageUploadHook,
 } from "@/hooks/useToastUiEditorImageUploadHook"
 import { useSelectTagList } from "@/hooks/useSelectTagList"
@@ -46,6 +44,7 @@ import type {
 } from "./AskQuestionPageControl"
 import { useResetRecoilState } from "recoil"
 import { searchTagAtom } from "@/recoil/atoms/tag"
+import Limitation from "@/constants/limitation"
 
 export interface QuestionEditorInitialValues {
   title: string
@@ -145,6 +144,7 @@ function AskQuestionForm({
 
         toast.error("이미지 업로드에 실패했습니다", {
           position: "top-center",
+          toastId: "imageUploadError",
         })
       },
       onError({ errorCase }) {
@@ -159,7 +159,7 @@ function AskQuestionForm({
 
         if (errorCase === "isMaximumSize") {
           toast.error(
-            `이미지 파일 업로드는 최대 ${MAXIMUN_UPLOAD_IMAGE_SIZE.toString()} 가능합니다`,
+            `이미지 파일 업로드는 최대 ${Limitation.image.stringifyedValue} 가능합니다`,
             {
               position: "top-center",
               toastId: "imageSizeError",
@@ -171,9 +171,7 @@ function AskQuestionForm({
 
         if (errorCase === "notAllowedExtension") {
           toast.error(
-            `이미지 파일 업로드는 ${ALLOW_IMAGE_TYPES.map((imageType) =>
-              imageType.replace("image/", "").replace("+xml", ""),
-            ).join(", ")} 확장자만 가능합니다`,
+            `이미지 파일 업로드는 ${Limitation.image.extension.toString()} 확장자만 가능합니다`,
             { position: "top-center", toastId: "imageExtensionError" },
           )
 
@@ -239,7 +237,10 @@ function AskQuestionForm({
         return
       }
 
-      toast.error("질문 생성에 실패했습니다", { position: "bottom-center" })
+      toast.error("질문 생성에 실패했습니다", {
+        position: "bottom-center",
+        toastId: "createQuestionError",
+      })
 
       return
     }
@@ -297,7 +298,10 @@ function AskQuestionForm({
       return
     }
 
-    toast.error("질문 수정에 실패했습니다", { position: "bottom-center" })
+    toast.error("질문 수정에 실패했습니다", {
+      position: "bottom-center",
+      toastId: "updateQuestionError",
+    })
   }
 
   const onInvalid = async (errors: FieldErrors<AskQuestionFormData>) => {
@@ -308,9 +312,9 @@ function AskQuestionForm({
           case "required":
             return "제목을 입력해주세요"
           case "minLength":
-            return "제목은 최소 5자 이상 가능합니다"
+            return `제목은 최소 ${Limitation.title_limit_under}자 이상 가능합니다`
           case "maxLength":
-            return "제목은 최대 100자까지 가능합니다"
+            return `제목은 최대 ${Limitation.question_title_limit_over}자까지 가능합니다`
         }
       })(errors.title.type)
 
@@ -338,9 +342,9 @@ function AskQuestionForm({
           case "required":
             return "본문을 입력해주세요"
           case "minLength":
-            return "본문은 최소 10자 이상 가능합니다"
+            return `본문은 최소 ${Limitation.content_limit_under}자 이상 가능합니다`
           case "maxLength":
-            return "본문은 최대 10,000자까지 가능합니다"
+            return `본문은 최대 ${Limitation.question_content_limit_over}자까지 가능합니다`
         }
       })(errors.content.type)
 
@@ -410,8 +414,8 @@ function AskQuestionForm({
             placeholder="제목"
             {...register("title", {
               required: true,
-              minLength: 5,
-              maxLength: 100,
+              minLength: Limitation.title_limit_under,
+              maxLength: Limitation.question_title_limit_over,
               disabled: !loaded,
               onChange(event) {
                 updateQuestionEditorState({
@@ -456,8 +460,8 @@ function AskQuestionForm({
             spellCheck="false"
             {...register("content", {
               required: true,
-              minLength: 10,
-              maxLength: 10000,
+              minLength: Limitation.content_limit_under,
+              maxLength: Limitation.question_content_limit_over,
             })}
           />
         </div>

--- a/src/page/qna-detail/components/Markdown/MdEditor.tsx
+++ b/src/page/qna-detail/components/Markdown/MdEditor.tsx
@@ -2,7 +2,6 @@
 
 import MarkdownEditor from "@/components/shared/markdown/Editor/MarkdownEditor"
 import { errorMessage } from "@/constants/message"
-import { MAXIMUM_UPLOAD_IMAGE_LENGTH } from "@/hooks/useToastUiEditorImageUploadHook"
 import {
   answerEditorAtomFamily,
   answerEditorLoadedAtomFamily,
@@ -63,10 +62,10 @@ const MdEditor: React.FC<EditorProps> = ({
     },
     onError({ errorCase }) {
       if (errorCase === "isMaximum") {
-        toast.error(
-          `이미지 파일 업로드는 최대 ${MAXIMUM_UPLOAD_IMAGE_LENGTH}장 가능합니다`,
-          { toastId: "overAnswerImageLimit", position: "top-center" },
-        )
+        toast.error(errorMessage.imageUploadLimit, {
+          toastId: "overAnswerImageLimit",
+          position: "top-center",
+        })
 
         return
       }

--- a/src/page/qna-detail/hooks/useToastUiEditorImageUploadHook.tsx
+++ b/src/page/qna-detail/hooks/useToastUiEditorImageUploadHook.tsx
@@ -8,6 +8,7 @@ import type { APIResponse } from "@/interfaces/dto/api-response"
 import type { UploadImagesCategory } from "@/interfaces/dto/upload/upload-images.dto"
 import { useUploadImage } from "@/hooks/image/useUploadImage"
 import { answerEditorAtomFamily } from "@/recoil/atoms/answerEditor"
+import Limitation from "@/constants/limitation"
 
 type SuccessCallbackArg = {
   file: File
@@ -49,13 +50,11 @@ export const exceedingUploadableImagesError = new Error(
   { cause: "exceeding uploadable images" },
 )
 
-export const MAXIMUM_UPLOAD_IMAGE_LENGTH = 1
-
 export function useAnswerToastUiEditorImageUploadHook({
   atomKey,
   category,
   action,
-  maximumUploadImageLength = MAXIMUM_UPLOAD_IMAGE_LENGTH,
+  maximumUploadImageLength = Limitation.image.upload.maxLength,
   onUploadSuccess,
   onUploadError,
   onError,

--- a/src/page/user-profile/hooks/useProfileImage.tsx
+++ b/src/page/user-profile/hooks/useProfileImage.tsx
@@ -98,10 +98,10 @@ const useProfileImage = (image_url: string | null) => {
   ) => {
     if (event.target.files) {
       const file = event.target.files[0]
-      console.log("image size", file.size, file.size > Limitation.image_size)
+      console.log("image size", file.size, file.size > Limitation.image.size)
 
       // 파일 용량 제한
-      if (file.size > Limitation.image_size) {
+      if (file.size > Limitation.image.size) {
         toast.error(errorMessage.imageLimitOver, {
           position: "top-center",
           toastId: "profileImageLimitOver",


### PR DESCRIPTION
## 관련 이슈

close: [#165](https://github.com/KernelSquare/Frontend/issues/165)

## 개요

> 질문과 관련된 제한(유효성)을 적용

## 상세 내용
- 기존 Limitation 을 활용하는 방향으로 로직 적용
- 업로드 이미지 최대 개수도 Limitation에 포함할지는 서로 논의해서 수정해야 될 것 같아 해당 이슈에서는 적용하지 않음
