### PR TITLE
fix: 지도 정보 수정

### DIFF
--- a/src/page/coding-meetings/create/components/CustomMap/kakaoMap.tsx
+++ b/src/page/coding-meetings/create/components/CustomMap/kakaoMap.tsx
@@ -48,8 +48,8 @@ export default function KakaoMapPage({ keyword }: { keyword: string }) {
             // @ts-ignore
             markers.push({
               position: {
-                lat: data[i].y,
-                lng: data[i].x,
+                lat: data[i].x,
+                lng: data[i].y,
               },
               content: data[i].place_name,
             })


### PR DESCRIPTION
## 개요

> 모각코 생성 시 지도 좌표 정보 수정

## 상세 내용

- 지도 좌표 정보가 반대로 들어가는 것을 수정하였습니다.
