### PR TITLE
fix: 수정 시 데이터 반영 지연 문제 해결 

### DIFF
--- a/src/page/coding-meetings/create/CreateCodingMeetingPage.tsx
+++ b/src/page/coding-meetings/create/CreateCodingMeetingPage.tsx
@@ -32,6 +32,7 @@ import { LocationForSubmit } from "@/recoil/atoms/coding-meeting/mapData"
 import Limitation from "@/constants/limitation"
 import type { CodingMeetingDetailPayload } from "@/interfaces/dto/coding-meeting/get-coding-meeting-detail.dto"
 import NotFound from "@/app/not-found"
+import { revalidatePage } from "@/util/actions/revalidatePage"
 
 interface CreateCodingMeetingPageProps {
   editMode: "create" | "update"
@@ -184,7 +185,7 @@ const CreateCodingMeetingPage = ({
           queryClient.invalidateQueries({
             queryKey: ["codingMeeting"],
           })
-
+          revalidatePage("/coding-meetings/[token]", "page")
           replace(`/coding-meetings/${coding_meeting_token}`)
 
           setHash_tags([])

--- a/src/page/coding-meetings/create/components/LocationSection.tsx
+++ b/src/page/coding-meetings/create/components/LocationSection.tsx
@@ -9,7 +9,6 @@ import {
   DialogClose,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,


### PR DESCRIPTION
## 개요

> 모각코 게시글 수정 후 상세 페이지로의 이동 시 새로고침 없이도 데이터가 반영될 수 있도록 라우터 캐시를 초기화하였습니다.