### PR TITLE
fix: 모각코 상세, 메인

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-hover-card": "^1.0.7",
+    "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",
     "@sentry/nextjs": "^7.101.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   '@radix-ui/react-hover-card':
     specifier: ^1.0.7
     version: 1.0.7(@types/react-dom@18.2.17)(@types/react@18.2.43)(react-dom@18.2.0)(react@18.2.0)
+  '@radix-ui/react-popover':
+    specifier: ^1.0.7
+    version: 1.0.7(@types/react-dom@18.2.17)(@types/react@18.2.43)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-select':
     specifier: ^2.0.0
     version: 2.0.0(@types/react-dom@18.2.17)(@types/react@18.2.43)(react-dom@18.2.0)(react@18.2.0)
@@ -1236,6 +1239,41 @@ packages:
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.43)(react@18.2.0)
       '@types/react': 18.2.43
       react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-popover@1.0.7(@types/react-dom@18.2.17)(@types/react@18.2.43)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-shtvVnlsxT6faMnK/a7n0wptwBD23xc1Z5mdrtKLwVEfsEMXodS0r5s0/g5P0hX//EKYZS2sxUjqfzlg52ZSnQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.5
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.43)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.43)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.2.17)(@types/react@18.2.43)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.43)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.4(@types/react-dom@18.2.17)(@types/react@18.2.43)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.43)(react@18.2.0)
+      '@radix-ui/react-popper': 1.1.3(@types/react-dom@18.2.17)(@types/react@18.2.43)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.2.17)(@types/react@18.2.43)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.17)(@types/react@18.2.43)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.17)(@types/react@18.2.43)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.43)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.43)(react@18.2.0)
+      '@types/react': 18.2.43
+      '@types/react-dom': 18.2.17
+      aria-hidden: 1.2.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.5.5(@types/react@18.2.43)(react@18.2.0)
     dev: false
 
   /@radix-ui/react-popper@1.1.3(@types/react-dom@18.2.17)(@types/react@18.2.43)(react-dom@18.2.0)(react@18.2.0):

--- a/src/app/coding-meetings/[token]/page.tsx
+++ b/src/app/coding-meetings/[token]/page.tsx
@@ -5,6 +5,7 @@ import { APIResponse } from "@/interfaces/dto/api-response"
 import { notFound } from "next/navigation"
 import { getCodingMeetingDetail } from "@/service/coding-meetings"
 import DetailHeader from "@/page/coding-meetings/detail/DetailHeader"
+import ScrollTopButton from "@/page/coding-meetings/main/ScrollTopButton"
 
 export interface CodingMeetingsDetailPageProps {
   params: {
@@ -32,6 +33,7 @@ export default async function CodingMeetingsDetailPage({
           <CodingMeetingsDetail detail={detailResponse.data.data!} />
         </div>
         <aside className="bg-transparent min-h-screen hidden lg:block lg:w-32" />
+        <ScrollTopButton />
       </div>
     )
   } catch (error) {

--- a/src/components/shared/page-template/ListPage.tsx
+++ b/src/components/shared/page-template/ListPage.tsx
@@ -3,6 +3,13 @@
 import CodingMeetingInfoArea from "@/page/coding-meetings/main/info-area/InfoArea"
 import ListLoading from "../animation/ListLoading"
 import CodingMeetingTabs from "@/page/coding-meetings/main/Tab"
+import { Icons } from "@/components/icons/Icons"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/PopOver"
+import { PopoverClose } from "@radix-ui/react-popover"
 
 interface ListPageProps {
   section: "qna" | "codingMeetings"
@@ -27,14 +34,47 @@ export default ListPage
 
 function Title({ section }: { section: ListPageProps["section"] }) {
   const title = {
-    qna: "개발자 Q&A",
-    codingMeetings: "모각코",
+    qna: <h3>개발자 Q&A</h3>,
+    codingMeetings: (
+      <section className="w-full flex shrink-0 items-center gap-1">
+        <h4 className="mb-1">모각코</h4>
+        <Popover>
+          <PopoverTrigger>
+            <Icons.Info className="text-base" />
+          </PopoverTrigger>
+          <PopoverContent
+            hideWhenDetached={true}
+            side="right"
+            align="start"
+            sticky="always"
+            alignOffset={4}
+            className="w-36 border border-[#828282] bg-white rounded-lg text-base p-4"
+          >
+            <section className="relative">
+              <PopoverClose className="absolute -top-2 -right-2">
+                <Icons.Close className="text-sm" />
+              </PopoverClose>
+              <h4 className="font-bold text-xs">모각코?</h4>
+              <article className="text-sm">
+                모각코는
+                <br />
+                <span className="text-primary">모여서 각자 코딩</span>의
+                줄임말로,
+                <br />
+                여러 사람이 같은 공간에 모여 각자의 코딩 공부나 프로젝트를
+                진행하는 활동이에요.
+              </article>
+            </section>
+          </PopoverContent>
+        </Popover>
+      </section>
+    ),
   } satisfies Record<typeof section, React.ReactNode>
 
   return (
-    <h3 className="text-[#333333] text-[32px] font-semibold mb-6 tablet:mb-8 lg:mb-12">
+    <section className="text-[#333333] text-[32px] font-semibold mb-6 tablet:mb-8 lg:mb-12">
       {title[section]}
-    </h3>
+    </section>
   )
 }
 

--- a/src/components/ui/PopOver.tsx
+++ b/src/components/ui/PopOver.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverAnchor = PopoverPrimitive.Anchor
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/src/page/coding-meetings/detail/Comments.tsx
+++ b/src/page/coding-meetings/detail/Comments.tsx
@@ -62,6 +62,7 @@ function DetailComments({ author, token }: DetailCommentsProps) {
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { isSubmitting },
   } = useForm<CommentFormData>()
 
@@ -79,6 +80,8 @@ function DetailComments({ author, token }: DetailCommentsProps) {
       queryClient.invalidateQueries({
         queryKey: ["coding-meeting", "comment", token],
       })
+
+      setValue("comment", "")
     } catch (error) {
       const toastId = "commentError"
 

--- a/src/page/coding-meetings/detail/DetailPage.tsx
+++ b/src/page/coding-meetings/detail/DetailPage.tsx
@@ -5,22 +5,43 @@ import DetailMenu from "./DetailMenu"
 import Spacing from "@/components/shared/Spacing"
 import DetailSection from "./Section"
 import Link from "next/link"
-import DetailMap from "./Map"
 import HashTag from "@/components/shared/tag/HashTag"
 import DetailComments from "./Comments"
 import dynamic from "next/dynamic"
-import Skeleton from "react-loading-skeleton"
+import MapContainer from "./kakao-map/MapContainer"
+import { Icons } from "@/components/icons/Icons"
 
 interface CodingMeetingsDetailPageProps {
   detail: CodingMeetingDetailPayload
 }
+
+const DetailMap = dynamic(
+  () => import("@/page/coding-meetings/detail/kakao-map/Map"),
+  {
+    ssr: false,
+    loading(loadingProps) {
+      return (
+        <div className="absolute left-0 top-0 z-[2] w-full h-full flex flex-col justify-center items-center bg-white">
+          <div className="w-8 h-8 flex justify-center items-center rounded-full border border-[#828282]">
+            <Icons.MapMarker className="text-[#828282]" />
+          </div>
+          <div className="mt-5 text-sm text-[#828282]">카카오 맵 로드 중</div>
+        </div>
+      )
+    },
+  },
+)
 
 const DetailCodingMeetingTime = dynamic(
   () => import("@/page/coding-meetings/detail/DetailTime"),
   {
     ssr: false,
     loading(loadingProps) {
-      return <Skeleton className="w-12 h-6 shrink-0 rounded-lg" />
+      return (
+        <div className="flex items-center h-5 text-sm text-[#828282]">
+          한국 시간(KST)으로 변환 중
+        </div>
+      )
     },
   },
 )
@@ -80,11 +101,13 @@ const CodingMeetingsDetailPage = ({
               </DetailSection>
             </div>
             <div className="relative border border-colorsGray rounded-lg overflow-hidden mt-6 tablet:mt-0 w-full aspect-[1.114/1] tablet:w-auto tablet:aspect-[1.116/1] tablet:h-[323px] lg:!h-[431px]">
-              <DetailMap
-                x={detail.coding_meeting_location_latitude}
-                y={detail.coding_meeting_location_longitude}
-                placeName={detail.coding_meeting_location_place_name}
-              />
+              <MapContainer>
+                <DetailMap
+                  x={detail.coding_meeting_location_latitude}
+                  y={detail.coding_meeting_location_longitude}
+                  placeName={detail.coding_meeting_location_place_name}
+                />
+              </MapContainer>
             </div>
           </div>
           <DetailSection className="mt-8 tablet:mt-6" title="소개글">

--- a/src/page/coding-meetings/detail/Map.tsx
+++ b/src/page/coding-meetings/detail/Map.tsx
@@ -23,7 +23,7 @@ function DetailMap({ x, y, placeName }: DetailMapProps) {
       level={3}
       style={{
         width: "100%",
-        height: "inherit",
+        height: "100%",
       }}
     >
       <MapMarker position={{ lat: Number(x), lng: Number(y) }} />

--- a/src/page/coding-meetings/detail/UserInfo.tsx
+++ b/src/page/coding-meetings/detail/UserInfo.tsx
@@ -23,8 +23,8 @@ function UserInfo({ user }: UserInfoProps) {
     }
   return (
     <div
-      className={`cursor-pointer inline-flex align-top flex-shrink-0 outline outline-2 outline-offset-2 outline-transparent rounded-lg ${
-        loginUser ? "hover:outline-primary" : ""
+      className={`inline-flex align-top flex-shrink-0 outline outline-2 outline-offset-2 outline-transparent rounded-lg ${
+        loginUser ? "cursor-pointer hover:outline-primary" : "cursor-default"
       }`}
       {...(loginUser && {
         onClick: goToUserProfile(user.member_id),
@@ -32,7 +32,10 @@ function UserInfo({ user }: UserInfoProps) {
       })}
     >
       <div className="flex gap-2 items-center">
-        <Profile profileImage={user.member_profile_url} />
+        <Profile
+          profileImage={user.member_profile_url}
+          className={loginUser ? "cursor-pointer" : "cursor-default"}
+        />
         <span className="font-semibold text-sm">{user.member_nickname}</span>
         <div className="flex gap-1 items-center">
           <div className="relative w-4 h-4">

--- a/src/page/coding-meetings/detail/kakao-map/Control.tsx
+++ b/src/page/coding-meetings/detail/kakao-map/Control.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { Icons } from "@/components/icons/Icons"
+import Button from "@/components/shared/button/Button"
+import { useState } from "react"
+import { FiZoomIn, FiZoomOut } from "react-icons/fi"
+import { useMap } from "react-kakao-maps-sdk"
+
+interface DetailMapControlProps {
+  maxZoomLevel: number
+  minZoomLevel: number
+  location: {
+    x: number
+    y: number
+  }
+}
+
+function DetailMapControl(
+  { maxZoomLevel, minZoomLevel, location }: DetailMapControlProps,
+  ref: React.ForwardedRef<kakao.maps.Map>,
+) {
+  const map = useMap()
+
+  const [disableZoom, setDisableZoom] = useState<{
+    zoomIn: boolean
+    zoomOut: boolean
+  }>({
+    zoomIn: false,
+    zoomOut: false,
+  })
+
+  function setDisable(map: kakao.maps.Map) {
+    const currentZoomLevel = map.getLevel()
+
+    setDisableZoom({
+      zoomIn: currentZoomLevel <= maxZoomLevel,
+      zoomOut: currentZoomLevel >= minZoomLevel,
+    })
+  }
+
+  const handleZoom =
+    (type: "zoomIn" | "zoomOut") =>
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (type === "zoomIn") {
+        map.setLevel(map.getLevel() - 1)
+        setDisable(map)
+
+        return
+      }
+
+      map.setLevel(map.getLevel() + 1)
+      setDisable(map)
+    }
+
+  const handleMoveMeetingLocation = (
+    e: React.MouseEvent<HTMLButtonElement>,
+  ) => {
+    map.setCenter(new kakao.maps.LatLng(location.x, location.y))
+  }
+
+  return (
+    <div className="absolute z-[4] top-2 right-2 border border-colorsDarkGray rounded-lg bg-white overflow-hidden">
+      <div className="w-full flex flex-col justify-center items-center">
+        <IconButton
+          title={"확대"}
+          onClick={handleZoom("zoomIn")}
+          disabled={disableZoom.zoomIn}
+        >
+          <FiZoomIn />
+        </IconButton>
+        <IconButton
+          title={"축소"}
+          onClick={handleZoom("zoomOut")}
+          disabled={disableZoom.zoomOut}
+        >
+          <FiZoomOut />
+        </IconButton>
+        <IconButton
+          title={"모임 장소로 이동"}
+          onClick={handleMoveMeetingLocation}
+        >
+          <Icons.MapMarker />
+        </IconButton>
+      </div>
+    </div>
+  )
+}
+
+export default DetailMapControl
+
+function IconButton({
+  children,
+  onClick,
+  disabled,
+  title,
+}: {
+  children: React.ReactNode
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void
+  disabled?: boolean
+  title?: string
+}) {
+  return (
+    <Button
+      className="rounded-none transition-colors w-full box-border flex justify-center items-center shrink-0 p-2 hover:bg-[#E0E0E0] disabled:hover:bg-[#828282] disabled:text-colorsDarkGray disabled:bg-[#828282]"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+    >
+      {children}
+    </Button>
+  )
+}

--- a/src/page/coding-meetings/detail/kakao-map/KakaoMapError.tsx
+++ b/src/page/coding-meetings/detail/kakao-map/KakaoMapError.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as Sentry from "@sentry/nextjs"
+import { Icons } from "@/components/icons/Icons"
+import { useEffect } from "react"
+import { FallbackProps } from "react-error-boundary"
+
+function KakakoMapError({ error }: FallbackProps) {
+  useEffect(() => {
+    Sentry.withScope((scope) => {
+      const sentryKakakoMapError = new Error("kakaoMap 에러")
+      sentryKakakoMapError.name = "카카오 Map"
+
+      Sentry.captureException(sentryKakakoMapError)
+    })
+  }, [error])
+
+  return (
+    <div className="absolute left-0 top-0 z-[2] w-full h-full flex flex-col justify-center items-center bg-white">
+      <div className="w-8 h-8 flex justify-center items-center rounded-full border border-[#828282]">
+        <Icons.MapMarker className="text-[#828282]" />
+      </div>
+      <div className="mt-5 text-sm text-[#828282]">카카오 맵 로드 실패</div>
+    </div>
+  )
+}
+
+export default KakakoMapError

--- a/src/page/coding-meetings/detail/kakao-map/Map.tsx
+++ b/src/page/coding-meetings/detail/kakao-map/Map.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Map, MapMarker, useKakaoLoader } from "react-kakao-maps-sdk"
+import DetailMapControl from "@/page/coding-meetings/detail/kakao-map/Control"
 
 interface DetailMapProps {
   x: string
@@ -9,10 +10,18 @@ interface DetailMapProps {
 }
 
 function DetailMap({ x, y, placeName }: DetailMapProps) {
-  useKakaoLoader({
+  const [loading, error] = useKakaoLoader({
     appkey: process.env.NEXT_PUBLIC_KAKAO_MAP!,
     libraries: ["services"],
   })
+
+  const zoomLevel = {
+    max: 1,
+    min: 6,
+    initial: 3,
+  }
+
+  if (error) throw error
 
   return (
     <Map
@@ -20,13 +29,24 @@ function DetailMap({ x, y, placeName }: DetailMapProps) {
         lat: Number(x),
         lng: Number(y),
       }}
-      level={3}
+      zoomable={false}
+      level={zoomLevel.initial}
+      maxLevel={zoomLevel.max}
+      minLevel={zoomLevel.min}
       style={{
         width: "100%",
         height: "100%",
       }}
     >
       <MapMarker position={{ lat: Number(x), lng: Number(y) }} />
+      <DetailMapControl
+        maxZoomLevel={zoomLevel.max}
+        minZoomLevel={zoomLevel.min}
+        location={{
+          x: Number(x),
+          y: Number(y),
+        }}
+      />
     </Map>
   )
 }

--- a/src/page/coding-meetings/detail/kakao-map/MapContainer.tsx
+++ b/src/page/coding-meetings/detail/kakao-map/MapContainer.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { ErrorBoundary } from "react-error-boundary"
+import KakakoMapError from "./KakaoMapError"
+
+interface MapContainerProps {
+  children: React.ReactNode
+}
+
+function MapContainer({ children }: MapContainerProps) {
+  return (
+    <ErrorBoundary FallbackComponent={KakakoMapError}>{children}</ErrorBoundary>
+  )
+}
+
+export default MapContainer

--- a/src/page/coding-meetings/main/ScrollTopButton.tsx
+++ b/src/page/coding-meetings/main/ScrollTopButton.tsx
@@ -26,12 +26,6 @@ function ScrollTopButton() {
       return throttle((e: Event) => {
         const currentScrollY = window.scrollY
 
-        if (document.body.clientWidth >= 480) {
-          prevScrollY = currentScrollY
-
-          return
-        }
-
         if (currentScrollY === 0) {
           debounceHandleShow.cancel()
 
@@ -64,14 +58,14 @@ function ScrollTopButton() {
 
   return (
     <div
-      className={`fixed right-2 bottom-9 z-10 transition-opacity ease-in-out ${
+      className={`fixed right-2 bottom-9 z-10 transition-opacity ease-in-out lg:right-20 ${
         show
           ? "pointer-events-auto opacity-100"
           : "pointer-events-none opacity-0"
       }`}
     >
       <button
-        className="shadow-[0_0_8px_0_rgba(0,0,0,.16)] flex flex-col justify-center items-center editor:hidden w-12 h-12 font-bold rounded-full outline-none box-border p-2 cursor-pointer bg-secondary"
+        className="shadow-[0_0_8px_0_rgba(0,0,0,.16)] flex flex-col justify-center items-center w-12 h-12 lg:w-16 lg:h-16 font-bold rounded-full outline-none box-border p-2 cursor-pointer bg-secondary"
         onClick={scrollToTop}
       >
         <IoIosArrowUp className="text-white text-xl shrink-0 -mt-1" />


### PR DESCRIPTION
## 관련 이슈

close: [#207](https://github.com/KernelSquare/Frontend/issues/207)

## 개요

> 모각코 상세 QA 반영

## 상세 내용

### 메인
- 상단 타이틀에 모각코 툴팁 생성

### 상세
- 로그인 하지 않은 유저가 유저 영역 hover시 커서가 포인터로 변경되지 않도록 수정
- 지도 컴포넌트 height 수정
- 기본 지도 스크롤 이벤트의 줌인/줌아웃 이벤트를 비활성화 시키고, 사용자가 원할 경우 직접 확대 축소 버튼을 눌러서 볼 수 있도록 수정
  -  페이지를 스크롤 할 때 원치 않는 지도 확대 축소 는 사용자 경험에 안 좋을 것이라 생각 되어 수정
  -  수정 이후 기존 스크롤 이벤트를 원하는 것으로 피드백이 올 경우 기존 이벤트를 허용하는 것으로 수정하여 다시 반영할 예정
- 카카오 맵 로드, 실패 렌더링 / 해당 에러 발생시 Sentry에 에러 전송
- 서버 시간 -> 한국 시간(클라이언트 기준) 시간 컴포넌트 클라이언트 환경에서 렌더링되기 이전까지의 로딩 렌더링 추가
- 댓글 작성 이후 댓글 입력 초기화
- 화면 최상단으로 이동 할 수 있는 scrollTop 버튼 추가
