### PR TITLE
fix: 메인 리스트 줄바꿈

### DIFF
--- a/src/page/coding-meetings/main/coding-meeting-list/CodingMeetingList.tsx
+++ b/src/page/coding-meetings/main/coding-meeting-list/CodingMeetingList.tsx
@@ -77,7 +77,7 @@ function CodingMeetingList({ codingMeetings }: CodingMeetingListProps) {
                   <h3 className="w-fit">
                     <Link
                       href={detailHref(coding_meeting_token)}
-                      className="max-w-full line-clamp-2 text-ellipsis text-blue-400"
+                      className="max-w-full break-all line-clamp-2 text-ellipsis text-blue-400"
                     >
                       {coding_meeting_title}
                     </Link>


### PR DESCRIPTION
## 관련 이슈

close: [#210](https://github.com/KernelSquare/Frontend/issues/210)

## 개요

> 모각코 리스트 제목이 길 경우 줄바꿈이 되지 않는 현상 수정

## 상세 내용

- 모각코 리스트 제목이 길 경우 줄바꿈이 되지 않는 현상 수정
