### PR TITLE
fix: 2차 QA 피드백 반영

### DIFF
--- a/src/app/coding-meetings/[token]/page.tsx
+++ b/src/app/coding-meetings/[token]/page.tsx
@@ -7,6 +7,9 @@ import { getCodingMeetingDetail } from "@/service/coding-meetings"
 import DetailHeader from "@/page/coding-meetings/detail/DetailHeader"
 import ScrollTopButton from "@/page/coding-meetings/main/ScrollTopButton"
 
+export const dynamic = "force-dynamic"
+export const revalidate = 0
+
 export interface CodingMeetingsDetailPageProps {
   params: {
     token: string

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,5 +1,5 @@
-import Inner from "../shared/Inner"
 import ScrollToTop from "../shared/scroll-to-top/ScrollToTop"
+import LayoutInner from "./LayoutInner"
 import Footer from "./footer/Footer"
 import Header from "./header/Header"
 import Navigation from "./navigation/Navigation"
@@ -8,10 +8,10 @@ function Layout({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Header />
-      <Inner className="flex w-full flex-col sm:flex-row">
+      <LayoutInner>
         <Navigation />
         <main className="min-h-screen flex-1">{children}</main>
-      </Inner>
+      </LayoutInner>
       <ScrollToTop />
       <Footer />
     </>

--- a/src/components/layout/LayoutInner.tsx
+++ b/src/components/layout/LayoutInner.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import { usePathname } from "next/navigation"
+import Inner from "../shared/Inner"
+
+interface LayoutInner {
+  children: React.ReactNode
+}
+
+function LayoutInner({ children }: LayoutInner) {
+  const pathname = usePathname()
+
+  const isLandingPage = pathname === "/"
+
+  if (isLandingPage)
+    return (
+      <Inner className="max-w-screen-3xl w-full h-screen">{children}</Inner>
+    )
+
+  return <Inner className="flex w-full flex-col sm:flex-row">{children}</Inner>
+}
+
+export default LayoutInner

--- a/src/components/shared/Inner.tsx
+++ b/src/components/shared/Inner.tsx
@@ -5,7 +5,7 @@ interface InnerProps
   extends PropsWithChildren<HTMLAttributes<HTMLDivElement>> {}
 
 function Inner({ children, className, ...props }: InnerProps) {
-  const classNames = twMerge(["mx-auto max-w-screen-3xl w-full", className])
+  const classNames = twMerge(["mx-auto max-w-screen-2xl w-full", className])
 
   return (
     <div className={classNames} {...props}>

--- a/src/components/shared/confirm-modal/ConfirmModal.tsx
+++ b/src/components/shared/confirm-modal/ConfirmModal.tsx
@@ -11,7 +11,7 @@ type PromiseFunc = () => Promise<void>
 
 interface ConfirmModalProps {
   onSuccess: BasicFunc | PromiseFunc
-  onCancel: BasicFunc | PromiseFunc
+  onCancel?: BasicFunc | PromiseFunc
   situation: MessageKey
 }
 
@@ -45,7 +45,7 @@ ConfirmModal.ModalContent = function ConfirmModal({
     closeModal()
   }
   const handleCancle = () => {
-    onCancel()
+    if (onCancel) onCancel()
     closeModal()
   }
 

--- a/src/constants/limitation.ts
+++ b/src/constants/limitation.ts
@@ -32,6 +32,8 @@ const Limitation = {
   title_limit_over: 100,
   content_limit_under: 10,
   content_limit_over: 10000,
+  answer_limit_under: 10,
+  answer_limit_over: 10000,
   introduction_limit_under: 10,
   introduction_limit_over: 1000,
   image: {

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -31,6 +31,7 @@ export const errorMessage = {
     "자기소개글 수정 중 오류가 발생하였습니다. 다시 시도해주세요.",
   failToVote: "투표 진행 중 오류가 발생하였습니다. 다시 시도해주세요.",
   failToSearchLocation: "장소 검색 중 오류가 발생하였습니다.",
+  failToCreateCoffeeChat: "커피챗 모집글 생성 중 오류가 발생하였습니다.",
   emptyCookie: "쿠키가 비어있습니다.",
   deleteAnswer: "답변 삭제 중 오류가 발생하였습니다.",
   deleteQuestion: "질문 삭제 중 오류가 발생하였습니다.",

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -11,6 +11,8 @@ export const errorMessage = {
   noHeadCnt: "모임 인원을 설정해주세요",
   underContentLimit: `본문 내용은 최소 ${Limitation.content_limit_under}자 이상이어야 합니다.`,
   overContentLimit: `본문 내용은 최대 ${Limitation.content_limit_over}자 이하이어야 합니다.`,
+  underAnswerLimit: `댓글 내용은 최소 ${Limitation.answer_limit_under}자 이상이어야 합니다.`,
+  overAnswerLimit: `댓글 내용은 최대 ${Limitation.answer_limit_over}자 이하이어야 합니다.`,
   introductionLimitOver: `최대 ${Limitation.introduction_limit_over}자까지 입력 가능합니다.`,
   introductionLimitUnder: `최소 ${Limitation.introduction_limit_under}자 이상 입력해야 합니다.`,
   imageLimitOver: `${Limitation.image.stringifyedSize} 이하의 이미지만 업로드할 수 있습니다.`,

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -6,6 +6,7 @@ export const errorMessage = {
   underTitleLimit: `제목은 최소 ${Limitation.title_limit_under}자 이상이어야 합니다.`,
   overTitleLimit: `제목은 최대 ${Limitation.title_limit_over}자 이하이어야 합니다.`,
   noContent: "본문 내용을 작성해주세요",
+  noAnswerContent: "답변 내용을 작성해주세요",
   noTime: "정확한 시간대를 설정해주세요",
   noLocation: "모임 위치를 설정해주세요",
   noHeadCnt: "모임 인원을 설정해주세요",

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -43,6 +43,8 @@ export const errorMessage = {
   duplicatedVote: "답변에 대한 투표는 한 번만 진행할 수 있습니다.",
   failToReserve: "커피챗 예약 중 오류가 발생하였습니다. 다시 시도해주세요.",
   failToCancleReservation: "커피챗 예약 취소 중 오류가 발생하였습니다.",
+  failToCreateCodingMeeting: "모각코 생성 중 오류가 발생하였습니다.",
+  failToUpdateCodingMeeting: "모각코 수정 중 오류가 발생하였습니다.",
   alreadyReserved: "이미 예약된 시간대입니다.",
   alreadySelected: "이미 선택된 시간대입니다.",
   youAlreadyReserved: "이미 동일한 멘토링을 예약하셨습니다.",

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -42,6 +42,7 @@ export const errorMessage = {
   saySorry: "이용에 불편을 드려 죄송해요.",
   duplicatedVote: "답변에 대한 투표는 한 번만 진행할 수 있습니다.",
   failToReserve: "커피챗 예약 중 오류가 발생하였습니다. 다시 시도해주세요.",
+  failToCancleReservation: "커피챗 예약 취소 중 오류가 발생하였습니다.",
   alreadyReserved: "이미 예약된 시간대입니다.",
   alreadySelected: "이미 선택된 시간대입니다.",
   youAlreadyReserved: "이미 동일한 멘토링을 예약하셨습니다.",

--- a/src/constants/timeOptions.ts
+++ b/src/constants/timeOptions.ts
@@ -52,7 +52,6 @@ export const PM = [
   "23:30",
 ]
 
-const range = ["오전", "오후"]
-const hours = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"]
+const hours = Array.from({ length: 24 }, (_, i) => i + "")
 const minutes = ["00", "30"]
-export const timeSelect = { range, hours, minutes }
+export const timeSelect = { hours, minutes }

--- a/src/mocks/handler/coffee-chat.ts
+++ b/src/mocks/handler/coffee-chat.ts
@@ -459,7 +459,7 @@ export const coffeeChatHandler = [
     async ({ params }) => {
       const reservationId = Number(params.id)
 
-      const targetReservation = MockReservations.find(
+      const targetReservation = MockReservations.findIndex(
         (res) => res.reservation_id === reservationId,
       )
 

--- a/src/page/coding-meetings/create/CreateCodingMeetingPage.tsx
+++ b/src/page/coding-meetings/create/CreateCodingMeetingPage.tsx
@@ -33,6 +33,7 @@ import Limitation from "@/constants/limitation"
 import type { CodingMeetingDetailPayload } from "@/interfaces/dto/coding-meeting/get-coding-meeting-detail.dto"
 import NotFound from "@/app/not-found"
 import { revalidatePage } from "@/util/actions/revalidatePage"
+import queryKey from "@/constants/queryKey"
 
 interface CreateCodingMeetingPageProps {
   editMode: "create" | "update"
@@ -57,8 +58,9 @@ const CreateCodingMeetingPage = ({
   const [endTime, setEndTime] = useRecoilState(EndTime)
   const [location, setLocation] = useRecoilState(LocationForSubmit)
   const queryClient = useQueryClient()
-  const { replace } = useRouter()
+  const { replace, push } = useRouter()
   const { user } = useClientSession()
+
   const { register, handleSubmit } = useForm<CodingMeetingFormData>(
     initialValues
       ? {
@@ -148,7 +150,7 @@ const CreateCodingMeetingPage = ({
       createCodingMeetingPost(payload, {
         onSuccess: (res) => {
           queryClient.invalidateQueries({
-            queryKey: ["codingMeeting"],
+            queryKey: [queryKey.codingMeeting],
           })
 
           replace(`/coding-meetings/${res.data.data?.coding_meeting_token}`)
@@ -181,27 +183,31 @@ const CreateCodingMeetingPage = ({
         coding_meeting_token,
       }
       updateCodingMeeting(editPayload, {
-        onSuccess: (res) => {
-          queryClient.invalidateQueries({
-            queryKey: ["codingMeeting"],
+        onSuccess: async (res) => {
+          queryClient.resetQueries({
+            queryKey: [queryKey.codingMeeting],
           })
-          revalidatePage("/coding-meetings/[token]", "page")
-          replace(`/coding-meetings/${coding_meeting_token}`)
 
-          setHash_tags([])
-          setHead_cnt("3")
-          setDay(new Date())
-          setStartTime({
-            range: "",
-            hour: "",
-            minute: "",
-          })
-          setEndTime({
-            range: "",
-            hour: "",
-            minute: "",
-          })
-          setLocation(undefined)
+          await revalidatePage("/coding-meetings/[token]", "page")
+
+          setTimeout(() => {
+            replace(`/coding-meetings/${coding_meeting_token}`)
+
+            setHash_tags([])
+            setHead_cnt("3")
+            setDay(new Date())
+            setStartTime({
+              range: "",
+              hour: "",
+              minute: "",
+            })
+            setEndTime({
+              range: "",
+              hour: "",
+              minute: "",
+            })
+            setLocation(undefined)
+          }, 0)
         },
       })
     }

--- a/src/page/coding-meetings/create/CreateCodingMeetingPage.tsx
+++ b/src/page/coding-meetings/create/CreateCodingMeetingPage.tsx
@@ -282,7 +282,7 @@ const CreateCodingMeetingPage = ({
   return (
     <div className="w-[80%] m-auto">
       <div
-        className="flex text-[#828282] items-center mt-10 cursor-pointer"
+        className="flex text-[#828282] items-center mt-10 cursor-pointer w-[10%]"
         onClick={goToListPage}
       >
         <DirectionIcons.LeftLine className="text-2xl" />

--- a/src/page/coding-meetings/create/components/CustomMap/kakaoMap.tsx
+++ b/src/page/coding-meetings/create/components/CustomMap/kakaoMap.tsx
@@ -40,7 +40,7 @@ export default function KakaoMapPage({ keyword }: { keyword: string }) {
       ps.keywordSearch(keyword, (data, status, _pagination) => {
         if (status === kakao.maps.services.Status.OK) {
           // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
-          // LatLngBounds 객체에 좌표를 추가합니다
+          // LatLngBounds 객체에 좌표를 추가합니다.
           const bounds = new kakao.maps.LatLngBounds()
           let markers: Marker[] = []
           setMapData(data)

--- a/src/page/coding-meetings/create/components/DateTimeSection.tsx
+++ b/src/page/coding-meetings/create/components/DateTimeSection.tsx
@@ -23,50 +23,31 @@ import type {
   TimeBoxProps,
 } from "../CreateCodingMeetingPage.types"
 import dayjs from "dayjs"
+import useHandleCreateCodingMeetingTime from "../hooks/useHandleCreateCodingMeetingTime"
+import { formatDay } from "@/util/getDate"
 
 const DateTimeSection = ({ initialDateTime }: DateTimeSectionProps) => {
   const [date, setDate] = useRecoilState(CodingMeetingDay)
   const setStartTime = useSetRecoilState(StartTime)
   const setEndTime = useSetRecoilState(EndTime)
+  const { resetTimes, formatMinute } = useHandleCreateCodingMeetingTime()
 
   useLayoutEffect(() => {
     if (initialDateTime) {
-      const initialDate = dayjs(
-        initialDateTime.coding_meeting_start_time,
-      ).format("YYYY-MM-DD")
+      const initialDate = formatDay(initialDateTime.coding_meeting_start_time)
       const start = dayjs(initialDateTime.coding_meeting_start_time)
       const end = dayjs(initialDateTime.coding_meeting_end_time)
       setDate(new Date(initialDate))
       setStartTime({
-        range: start.format("a"),
-        hour:
-          (start.get("hour") > 12
-            ? start.subtract(12, "hour").get("hour")
-            : start.get("hour")) + "",
-        minute: start.get("minute") + "",
+        hour: start.get("hour") + "",
+        minute: formatMinute(start.get("minute")),
       })
       setEndTime({
-        range: end.format("a"),
-        hour:
-          (end.get("hour") > 12
-            ? end.subtract(12, "hour").get("hour")
-            : end.get("hour")) + "",
-        minute:
-          String(end.get("minute")).length === 1
-            ? "0" + String(end.get("minute"))
-            : end.get("minute") + "",
+        hour: end.get("hour") + "",
+        minute: formatMinute(end.get("minute")),
       })
     } else {
-      setStartTime({
-        range: "",
-        hour: "",
-        minute: "",
-      })
-      setEndTime({
-        range: "",
-        hour: "",
-        minute: "",
-      })
+      resetTimes()
     }
   }, [])
 
@@ -95,21 +76,12 @@ const DateTimeSection = ({ initialDateTime }: DateTimeSectionProps) => {
 export default DateTimeSection
 
 const TimeBox = ({ timeState, setTimeState, suffix }: TimeBoxProps) => {
-  const handleTimeChange = (
-    type: "range" | "hour" | "minute",
-    value: string,
-  ) => {
+  const handleTimeChange = (type: "hour" | "minute", value: string) => {
     setTimeState({ ...timeState, [type]: value })
   }
 
   return (
     <div className="flex items-center gap-2">
-      <SelectBox
-        targetArray={timeSelect.range}
-        placeholder="구분"
-        handler={(value: string) => handleTimeChange("range", value)}
-        defaultValue={timeState.range}
-      />
       <div>
         <SelectBox
           targetArray={timeSelect.hours}

--- a/src/page/coding-meetings/create/hooks/useHandleCreateCodingMeetingTime.tsx
+++ b/src/page/coding-meetings/create/hooks/useHandleCreateCodingMeetingTime.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import {
+  CodingMeetingDay,
+  EndTime,
+  StartTime,
+  type Time,
+} from "@/recoil/atoms/coding-meeting/dateTime"
+import { formatDay } from "@/util/getDate"
+import dayjs from "dayjs"
+import utc from "dayjs/plugin/utc"
+
+import { useRecoilState } from "recoil"
+
+const useHandleCreateCodingMeetingTime = () => {
+  const [day, setDay] = useRecoilState(CodingMeetingDay)
+  const [startTime, setStartTime] = useRecoilState(StartTime)
+  const [endTime, setEndTime] = useRecoilState(EndTime)
+
+  const formattedDay = formatDay(day + "")
+  const formatMinute = (minute: number | string) =>
+    String(minute).length === 1 ? "0" + String(minute) : minute + ""
+
+  const formatTime = ({ hour, minute }: Time) => {
+    if (hour && hour.length === 1) hour = "0" + hour
+    return `${hour}:${minute}`
+  }
+  const formatByUTC = (time: string) => {
+    dayjs.extend(utc)
+    return dayjs(`${formattedDay} ${time}`).utc().format().slice(0, -1)
+  }
+
+  const resetTimes = () => {
+    setStartTime({
+      hour: "",
+      minute: "",
+    })
+    setEndTime({
+      hour: "",
+      minute: "",
+    })
+  }
+
+  const formattedStartTime = dayjs(`${formattedDay} ${formatTime(startTime)}`)
+  const formattedEndTime = dayjs(`${formattedDay} ${formatTime(endTime)}`)
+
+  const resetDateTimes = () => {
+    setDay(new Date())
+    setStartTime({
+      hour: "",
+      minute: "",
+    })
+    setEndTime({
+      hour: "",
+      minute: "",
+    })
+  }
+
+  return {
+    startTime,
+    endTime,
+    setStartTime,
+    setEndTime,
+    formatMinute,
+    formatTime,
+    formatByUTC,
+    resetTimes,
+    resetDateTimes,
+    formattedStartTime,
+    formattedEndTime,
+  }
+}
+
+export default useHandleCreateCodingMeetingTime

--- a/src/page/coffee-chat/create/CreateCoffeeChatReservationPage.tsx
+++ b/src/page/coffee-chat/create/CreateCoffeeChatReservationPage.tsx
@@ -46,7 +46,7 @@ function CreateCoffeeChatReservationPage({
 
   const { user } = useClientSession()
 
-  const { register, setFocus, handleSubmit } = useForm<CoffeeChatFormData>(
+  const { register, handleSubmit } = useForm<CoffeeChatFormData>(
     initialValues
       ? {
           defaultValues: {
@@ -73,7 +73,12 @@ function CreateCoffeeChatReservationPage({
       })
     if (data.title.length < Limitation.title_limit_under)
       return toast.error(errorMessage.underTitleLimit, {
-        toastId: "emptyCoffeeChatTitle",
+        toastId: "underCoffeeChatTitleLimit",
+        position: "top-center",
+      })
+    if (data.title.length > Limitation.title_limit_over)
+      return toast.error(errorMessage.overTitleLimit, {
+        toastId: "overCoffeeChatTitleLimit",
         position: "top-center",
       })
     if (

--- a/src/page/coffee-chat/create/CreateCoffeeChatReservationPage.tsx
+++ b/src/page/coffee-chat/create/CreateCoffeeChatReservationPage.tsx
@@ -28,6 +28,8 @@ import dynamic from "next/dynamic"
 import { TimeCount } from "@/recoil/atoms/coffee-chat/schedule"
 import { useGetScheduleList } from "./hooks/useGetScheduleList"
 import Limitation from "@/constants/limitation"
+import { AxiosError } from "axios"
+import { APIResponse } from "@/interfaces/dto/api-response"
 
 const MdEditor = dynamic(() => import("./components/MdEditor"), {
   ssr: false,
@@ -125,6 +127,26 @@ function CreateCoffeeChatReservationPage({
           replace(`/chat/${res.data.data?.reservation_article_id}`)
 
           setHash_tags([])
+        },
+        onError: (error: Error | AxiosError<APIResponse>) => {
+          if (error instanceof AxiosError) {
+            const { response } = error as AxiosError<APIResponse>
+
+            toast.error(
+              response?.data.msg ?? errorMessage.failToCreateCoffeeChat,
+              {
+                toastId: "failToCreateCoffeeChat",
+                position: "top-center",
+                autoClose: 1000,
+              },
+            )
+            return
+          }
+          toast.error(errorMessage.failToCreateCoffeeChat, {
+            toastId: "failToCreateCoffeeChat",
+            position: "top-center",
+            autoClose: 1000,
+          })
         },
       },
     )

--- a/src/page/coffee-chat/create/CreateCoffeeChatReservationPage.tsx
+++ b/src/page/coffee-chat/create/CreateCoffeeChatReservationPage.tsx
@@ -81,15 +81,28 @@ function CreateCoffeeChatReservationPage({
         toastId: "overCoffeeChatTitleLimit",
         position: "top-center",
       })
-    if (
-      !editorRef.current?.getInstance().getMarkdown() ||
-      editorRef.current?.getInstance().getMarkdown().length <
-        Limitation.content_limit_under
-    )
-      return toast.error(errorMessage.underContentLimit, {
+    if (!editorRef.current?.getInstance().getMarkdown())
+      return toast.error(errorMessage.noContent, {
         toastId: "emptyCoffeeChatContent",
         position: "top-center",
       })
+    if (
+      editorRef.current?.getInstance().getMarkdown().length <
+      Limitation.content_limit_under
+    )
+      return toast.error(errorMessage.underContentLimit, {
+        toastId: "underCoffeeChatContent",
+        position: "top-center",
+      })
+    if (
+      editorRef.current?.getInstance().getMarkdown().length >
+      Limitation.content_limit_over
+    )
+      return toast.error(errorMessage.overContentLimit, {
+        toastId: "overCoffeeChatContent",
+        position: "top-center",
+      })
+
     if (timeCount === 0)
       return toast.error(errorMessage.undertimeCntLimit, {
         toastId: "emptyCoffeeChatTime",

--- a/src/page/coffee-chat/detail/CoffeeChatDetailPage.tsx
+++ b/src/page/coffee-chat/detail/CoffeeChatDetailPage.tsx
@@ -42,7 +42,7 @@ function CoffeeChatDetailPage({
       <CoffeeChatDetailContent content={coffeeChatDetailPayload.content} />
       <Spacing size={32} />
       <div className="w-full flex justify-center items-center">
-        {isMentee && (
+        {user && isMentee && (
           <EnterCoffeeChat
             articleTitle={coffeeChatDetailPayload.title}
             roomId={matchRoom ? matchRoom.room_id : null}

--- a/src/page/coffee-chat/detail/reservation/mentee/TimeOptions.tsx
+++ b/src/page/coffee-chat/detail/reservation/mentee/TimeOptions.tsx
@@ -97,9 +97,20 @@ const TimeOptions = ({ reservation, cate, date }: TimeOptionsProps) => {
                 revalidatePage("/chat/[id]", "page")
               }, 0)
             },
-            onError: (res) => {
-              toast.error(res.message, {
-                toastId: "failToDeleteReservation",
+            onError: (error: Error | AxiosError<APIResponse>) => {
+              if (error instanceof AxiosError) {
+                const { response } = error as AxiosError<APIResponse>
+
+                toast.error(response?.data.msg ?? errorMessage.failToReserve, {
+                  toastId: "failToCancleReservation",
+                  position: "top-center",
+                  autoClose: 1000,
+                })
+                return
+              }
+
+              toast.error(errorMessage.failToCancleReservation, {
+                toastId: "failToCancleReservation",
                 position: "top-center",
                 autoClose: 1000,
               })

--- a/src/page/coffee-chat/detail/reservation/mentee/TimeOptions.tsx
+++ b/src/page/coffee-chat/detail/reservation/mentee/TimeOptions.tsx
@@ -22,6 +22,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import queryKey from "@/constants/queryKey"
 import { AxiosError } from "axios"
 import { APIResponse } from "@/interfaces/dto/api-response"
+import { revalidatePage } from "@/util/actions/revalidatePage"
 
 type TimeOptionsProps = {
   selectedDay: string
@@ -89,9 +90,12 @@ const TimeOptions = ({ reservation, cate, date }: TimeOptionsProps) => {
                 position: "top-center",
                 autoClose: 1000,
               })
-              queryClient.resetQueries({
-                queryKey: [queryKey.chat],
-              })
+              setTimeout(() => {
+                queryClient.resetQueries({
+                  queryKey: [queryKey.chat],
+                })
+                revalidatePage("/chat/[id]", "page")
+              }, 0)
             },
             onError: (res) => {
               toast.error(res.message, {
@@ -143,9 +147,12 @@ const TimeOptions = ({ reservation, cate, date }: TimeOptionsProps) => {
                 position: "top-center",
                 autoClose: 1000,
               })
-              queryClient.resetQueries({
-                queryKey: [queryKey.chat],
-              })
+              setTimeout(() => {
+                queryClient.resetQueries({
+                  queryKey: [queryKey.chat],
+                })
+                revalidatePage("/chat/[id]", "page")
+              }, 0)
             },
             onError: (error: Error | AxiosError<APIResponse>) => {
               if (error instanceof AxiosError) {

--- a/src/page/landing/Landing.tsx
+++ b/src/page/landing/Landing.tsx
@@ -3,7 +3,7 @@ import LandingSearchBar from "./components/LandingSearchBar"
 
 const LandingPage: React.FC = () => {
   return (
-    <div className="w-full h-screen">
+    <>
       <video
         width={"100%"}
         height={"100vh"}
@@ -17,7 +17,7 @@ const LandingPage: React.FC = () => {
         <source src="/video/landing_video.mp4" type="video/mp4" />
       </video>
       <LandingHeader />
-      <div className="absolute w-full flex-col items-center justify-center top-[40%] text-center">
+      <div className="absolute left-0 top-0 w-full h-full flex flex-col items-center justify-center text-center">
         <div className="font-bold text-5xl text-white">
           지속 가능한 개발자 커뮤니티,
         </div>
@@ -26,7 +26,7 @@ const LandingPage: React.FC = () => {
         </div>
         <LandingSearchBar />
       </div>
-    </div>
+    </>
   )
 }
 

--- a/src/page/landing/components/LandingHeader.tsx
+++ b/src/page/landing/components/LandingHeader.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation"
 const LandingHeader = () => {
   const router = useRouter()
   return (
-    <div className="w-full absolute top-0 py-5 flex justify-around items-center text-white text-xl bg-transparent">
+    <div className="w-full absolute top-0 py-5 flex justify-around items-center text-white text-xl bg-transparent z-[2]">
       <div className="cursor-pointer" onClick={() => router.push("/qna")}>
         개발자 Q&A
       </div>

--- a/src/page/landing/components/LandingSearchBar.tsx
+++ b/src/page/landing/components/LandingSearchBar.tsx
@@ -15,7 +15,7 @@ const LandingSearchBar = () => {
   })
 
   return (
-    <form onSubmit={handleSearch}>
+    <form onSubmit={handleSearch} className="w-full">
       <Controller
         name="search"
         control={control}

--- a/src/page/qna-detail/components/Answers/AnswerContentBox.tsx
+++ b/src/page/qna-detail/components/Answers/AnswerContentBox.tsx
@@ -17,6 +17,7 @@ import { findImageLinkUrlFromMarkdown } from "@/util/editor"
 import { UpdateAnswerRequest } from "@/interfaces/dto/answer/update-answer.dto"
 import { deleteImages } from "@/service/images"
 import Limitation from "@/constants/limitation"
+import TextCounter from "@/components/shared/TextCounter"
 
 export type EditAnswerProps = {
   answer: Answer
@@ -31,12 +32,13 @@ const MdEditor = dynamic(() => import("../Markdown/MdEditor"), {
 })
 
 export interface AnswerFormData {
-  content: string
+  answer: string
 }
 
 const AnswerContentBox: React.FC<EditAnswerProps> = ({ answer }) => {
   const editorRef = useRef<Editor>(null)
-  const { handleSubmit } = useForm<AnswerFormData>()
+  const { handleSubmit, register, setValue, getValues, watch } =
+    useForm<AnswerFormData>()
   const { isAnswerEditMode, setIsAnswerEditMode } = useHandleMyAnswer({
     answerId: Number(answer.answer_id),
     questionId: Number(answer.question_id),
@@ -53,7 +55,7 @@ const AnswerContentBox: React.FC<EditAnswerProps> = ({ answer }) => {
     const previousImage = answer.answer_image_url
     const submitValue = editorRef.current?.getInstance().getMarkdown()
     if (!submitValue || checkNullValue(submitValue)) {
-      toast.error(errorMessage.noContent, {
+      toast.error(errorMessage.noAnswerContent, {
         toastId: "emptyAnswerContent",
         position: "top-center",
         autoClose: 1000,
@@ -128,12 +130,29 @@ const AnswerContentBox: React.FC<EditAnswerProps> = ({ answer }) => {
           previous={answer.content}
           editorRef={editorRef}
           answerId={answer.answer_id}
+          onChange={() => {
+            setValue(
+              "answer",
+              editorRef.current?.getInstance().getMarkdown() ?? "",
+            )
+          }}
         />
+        <TextCounterBox text={watch("answer")} />
         <div className="flex justify-center my-5">
-          <Button buttonTheme="primary" className="p-2 w-[100px]" type="submit">
+          <Button
+            disabled={
+              !watch("answer") ||
+              watch("answer").length < Limitation.answer_limit_under ||
+              watch("answer").length > Limitation.answer_limit_over
+            }
+            buttonTheme="primary"
+            className="p-2 w-[100px] disabled:bg-colorsGray disabled:text-colorsDarkGray"
+            type="submit"
+          >
             저장하기
           </Button>
         </div>
+        <input hidden className="hidden" {...register("answer")} />
       </form>
     </Wrapper>
   )
@@ -144,3 +163,19 @@ export default AnswerContentBox
 const Wrapper: React.FC<PropsWithChildren> = ({ children }) => (
   <div className="w-[90%]">{children}</div>
 )
+
+type TextCounterBoxProps = {
+  text: string | undefined
+}
+
+const TextCounterBox = ({ text }: TextCounterBoxProps) => {
+  if (!text) return
+  return (
+    <TextCounter
+      text={text ?? ""}
+      min={Limitation.answer_limit_under}
+      max={Limitation.answer_limit_over}
+      className="text-lg block text-right h-5 py-2"
+    />
+  )
+}

--- a/src/page/qna-detail/components/Answers/AnswerContentBox.tsx
+++ b/src/page/qna-detail/components/Answers/AnswerContentBox.tsx
@@ -16,6 +16,7 @@ import type { Answer } from "@/interfaces/answer"
 import { findImageLinkUrlFromMarkdown } from "@/util/editor"
 import { UpdateAnswerRequest } from "@/interfaces/dto/answer/update-answer.dto"
 import { deleteImages } from "@/service/images"
+import Limitation from "@/constants/limitation"
 
 export type EditAnswerProps = {
   answer: Answer
@@ -54,6 +55,22 @@ const AnswerContentBox: React.FC<EditAnswerProps> = ({ answer }) => {
     if (!submitValue || checkNullValue(submitValue)) {
       toast.error(errorMessage.noContent, {
         toastId: "emptyAnswerContent",
+        position: "top-center",
+        autoClose: 1000,
+      })
+      return
+    }
+    if (submitValue.length < Limitation.answer_limit_under) {
+      toast.error(errorMessage.underAnswerLimit, {
+        toastId: "underAnswerLimit",
+        position: "top-center",
+        autoClose: 1000,
+      })
+      return
+    }
+    if (submitValue.length > Limitation.answer_limit_over) {
+      toast.error(errorMessage.overAnswerLimit, {
+        toastId: "overAnswerLimit",
         position: "top-center",
         autoClose: 1000,
       })

--- a/src/page/qna-detail/components/Answers/AnswerList.tsx
+++ b/src/page/qna-detail/components/Answers/AnswerList.tsx
@@ -42,7 +42,7 @@ const AnswerList: React.FC<AnswerProps> = ({
               className="mr-3"
               onChange={handleIsChecked}
             />
-            <label htmlFor="My Answer">내 답변 보기</label>
+            <label htmlFor="My Answer">내 답변만 보기</label>
           </div>
         </div>
         <div className="max-w-full box-border border border-colorsGray rounded-lg p-10 my-5">

--- a/src/page/qna-detail/components/Answers/HandleAnswerBox.tsx
+++ b/src/page/qna-detail/components/Answers/HandleAnswerBox.tsx
@@ -15,12 +15,13 @@ const HandleAnswerBox: React.FC<HandleAnswerProps> = ({
   createdby,
 }) => {
   const isMyAnswer = createdby === answer.created_by
-  const { handleEditMode, handleDeleteValue } = useHandleMyAnswer({
-    answerId: Number(answer.answer_id),
-    questionId: Number(answer.question_id),
-  })
+  const { handleEditMode, handleDeleteValue, isAnswerEditMode } =
+    useHandleMyAnswer({
+      answerId: Number(answer.answer_id),
+      questionId: Number(answer.question_id),
+    })
 
-  if (isMyAnswer)
+  if (isMyAnswer && !isAnswerEditMode)
     return (
       <div className="flex flex-wrap justify-end my-4">
         <div

--- a/src/page/qna-detail/components/Markdown/MdEditor.tsx
+++ b/src/page/qna-detail/components/Markdown/MdEditor.tsx
@@ -89,7 +89,7 @@ const MdEditor: React.FC<EditorProps> = ({
           hooks={{
             addImageBlobHook: uploadImageHook,
           }}
-          placeholder="질문을 작성해주세요."
+          placeholder="답변을 작성해주세요."
         />
       )}
     </div>

--- a/src/page/qna-detail/components/MyAnswer.tsx
+++ b/src/page/qna-detail/components/MyAnswer.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic"
 import { PropsWithChildren, useRef } from "react"
-import { useForm } from "react-hook-form"
+import { FieldErrors, useForm } from "react-hook-form"
 import { Editor } from "@toast-ui/react-editor"
 import Button from "@/components/shared/button/Button"
 import CreateAnswerAnime from "@/components/shared/animation/CreateAnswerAnime"
@@ -17,6 +17,8 @@ import useQnADetail from "../hooks/useQnADetail"
 import { Answer } from "@/interfaces/answer"
 import { toast } from "react-toastify"
 import Limitation from "@/constants/limitation"
+import TextCounter from "@/components/shared/TextCounter"
+import type { AnswerFormData } from "./Answers/AnswerContentBox"
 
 export interface MyAnswerProps {
   questionId: number
@@ -37,13 +39,13 @@ const MyAnswer: React.FC<MyAnswerProps> = ({ questionId, list, nickname }) => {
     checkNullValue,
   } = useQnADetail()
 
-  const { handleSubmit } = useForm()
+  const { register, setValue, handleSubmit, watch } = useForm<AnswerFormData>()
   const editorRef = useRef<Editor>(null)
 
   const handleSubmitAnswer = async () => {
     const submitValue = editorRef.current?.getInstance().getMarkdown()
     if (!submitValue || checkNullValue(submitValue)) {
-      toast.error(errorMessage.noContent, {
+      toast.error(errorMessage.noAnswerContent, {
         toastId: "emptyAnswerContent",
         position: "top-center",
         autoClose: 1000,
@@ -92,18 +94,36 @@ const MyAnswer: React.FC<MyAnswerProps> = ({ questionId, list, nickname }) => {
     handleCheckAbilityToWriteAnswer(list, nickname) && (
       <Container>
         <div>
-          <Title title="My Answer" />
+          <div className="flex items-center gap-2">
+            <Title title="My Answer" />
+            <TextCounterBox text={watch("answer")} />
+          </div>
           <form onSubmit={handleSubmit(handleSubmitAnswer)}>
-            <MdEditor editorRef={editorRef} previous="" />
+            <MdEditor
+              editorRef={editorRef}
+              previous=""
+              onChange={() => {
+                setValue(
+                  "answer",
+                  editorRef.current?.getInstance().getMarkdown() ?? "",
+                )
+              }}
+            />
             <div className="flex justify-center my-[20px]">
               <Button
+                disabled={
+                  !watch("answer") ||
+                  watch("answer").length < Limitation.answer_limit_under ||
+                  watch("answer").length > Limitation.answer_limit_over
+                }
                 buttonTheme="primary"
-                className="w-[200px] h-[50px] text-lg"
+                className="w-[200px] h-[50px] text-lg disabled:bg-colorsGray disabled:text-colorsDarkGray"
                 type="submit"
               >
                 {buttonMessage.postMyAnswer}
               </Button>
             </div>
+            <input hidden className="hidden" {...register("answer")} />
           </form>
         </div>
       </Container>
@@ -122,3 +142,19 @@ const Container = ({ children }: PropsWithChildren) => (
     {children}
   </div>
 )
+
+type TextCounterBoxProps = {
+  text: string | undefined
+}
+
+const TextCounterBox = ({ text }: TextCounterBoxProps) => {
+  if (!text) return
+  return (
+    <TextCounter
+      text={text ?? ""}
+      min={Limitation.answer_limit_under}
+      max={Limitation.answer_limit_over}
+      className="text-lg"
+    />
+  )
+}

--- a/src/page/qna-detail/components/MyAnswer.tsx
+++ b/src/page/qna-detail/components/MyAnswer.tsx
@@ -8,9 +8,15 @@ import Button from "@/components/shared/button/Button"
 import CreateAnswerAnime from "@/components/shared/animation/CreateAnswerAnime"
 import useModal from "@/hooks/useModal"
 import LoginForm from "@/components/form/LoginForm"
-import { buttonMessage, notificationMessage } from "@/constants/message"
+import {
+  buttonMessage,
+  errorMessage,
+  notificationMessage,
+} from "@/constants/message"
 import useQnADetail from "../hooks/useQnADetail"
 import { Answer } from "@/interfaces/answer"
+import { toast } from "react-toastify"
+import Limitation from "@/constants/limitation"
 
 export interface MyAnswerProps {
   questionId: number
@@ -24,14 +30,42 @@ const MdEditor = dynamic(() => import("../components/Markdown/MdEditor"), {
 
 const MyAnswer: React.FC<MyAnswerProps> = ({ questionId, list, nickname }) => {
   const { openModal } = useModal()
-  const { user, handleSubmitValue, handleCheckAbilityToWriteAnswer } =
-    useQnADetail()
+  const {
+    user,
+    handleSubmitValue,
+    handleCheckAbilityToWriteAnswer,
+    checkNullValue,
+  } = useQnADetail()
 
   const { handleSubmit } = useForm()
   const editorRef = useRef<Editor>(null)
 
   const handleSubmitAnswer = async () => {
     const submitValue = editorRef.current?.getInstance().getMarkdown()
+    if (!submitValue || checkNullValue(submitValue)) {
+      toast.error(errorMessage.noContent, {
+        toastId: "emptyAnswerContent",
+        position: "top-center",
+        autoClose: 1000,
+      })
+      return
+    }
+    if (submitValue.length < Limitation.answer_limit_under) {
+      toast.error(errorMessage.underAnswerLimit, {
+        toastId: "underAnswerLimit",
+        position: "top-center",
+        autoClose: 1000,
+      })
+      return
+    }
+    if (submitValue.length > Limitation.answer_limit_over) {
+      toast.error(errorMessage.overAnswerLimit, {
+        toastId: "overAnswerLimit",
+        position: "top-center",
+        autoClose: 1000,
+      })
+      return
+    }
     handleSubmitValue({ questionId, submitValue })
   }
 

--- a/src/page/qna-detail/hooks/useHandleQuestion.tsx
+++ b/src/page/qna-detail/hooks/useHandleQuestion.tsx
@@ -58,7 +58,7 @@ const useHandleQuestion = () => {
         queryClient.invalidateQueries({
           queryKey: [queryKey.question],
         })
-        router.replace("/")
+        router.replace("/qna")
       } catch (err) {
         console.error(err)
       }

--- a/src/page/qna-detail/hooks/useHandleQuestion.tsx
+++ b/src/page/qna-detail/hooks/useHandleQuestion.tsx
@@ -38,6 +38,7 @@ const useHandleQuestion = () => {
     const onSuccess = async () => {
       try {
         const imageUrl = findImageLinkUrlFromMarkdown(question.content)
+        console.log(imageUrl)
 
         deleteQuestion({
           questionId: question.id,
@@ -50,11 +51,7 @@ const useHandleQuestion = () => {
             })
           },
         })
-        if (imageUrl)
-          for (let image of imageUrl) {
-            const url = image.split("(")[1].split(")")[0]
-            deleteImage(url)
-          }
+        if (imageUrl) deleteImage(imageUrl[0])
         queryClient.invalidateQueries({
           queryKey: [queryKey.question],
         })

--- a/src/page/user-profile/components/UserProfileMenu.tsx
+++ b/src/page/user-profile/components/UserProfileMenu.tsx
@@ -53,11 +53,11 @@ function UserProfileMenu({ userPayload }: UserProfileMenuProps) {
           {
             label: "Introduction",
             content: (
-              <div className="flex w-full h-full justify-center mt-2">
+              <div className="flex w-full h-full justify-center items-center">
                 <Button>README.md</Button>
                 {isMyPage && (
                   <Icons.EditIntro
-                    className="ml-[2px] text-[16px] mt-[6px] hrink-0 cursor-pointer"
+                    className="ml-[2px] text-[16px] mt-[6px] shrink-0 cursor-pointer"
                     onClick={handleIntroductionEditMode}
                   />
                 )}

--- a/src/page/user-profile/components/UserProfileMenu.tsx
+++ b/src/page/user-profile/components/UserProfileMenu.tsx
@@ -69,7 +69,7 @@ function UserProfileMenu({ userPayload }: UserProfileMenuProps) {
       />
       <Spacing size={16} />
       {/* menu content */}
-      <UserProfileSection className="bg-white border-none shadow-none p-0">
+      <UserProfileSection className="bg-white border-none shadow-none p-0 sticky">
         <MenuContent />
       </UserProfileSection>
     </>

--- a/src/page/user-profile/components/profileImage/ProfileImage.tsx
+++ b/src/page/user-profile/components/profileImage/ProfileImage.tsx
@@ -27,7 +27,7 @@ const ProfileImage = ({ user_id, image_url }: ProfileImageProps) => {
         type="file"
         ref={imageUploadRef}
         className="hidden"
-        accept=".png, .jpeg, .svg, .gif"
+        accept="image/jpeg, image/png, image/svg+xml, image/gif"
         onChange={(e) => handleImageChange(e, user_id)}
       />
       {isMyPage && (

--- a/src/page/user-profile/hooks/useProfileImage.tsx
+++ b/src/page/user-profile/hooks/useProfileImage.tsx
@@ -112,9 +112,9 @@ const useProfileImage = (image_url: string | null) => {
 
       // 파일 확장자 제한
       if (
-        !file.type.includes("png") ||
-        !file.type.includes("svg") ||
-        !file.type.includes("jpeg") ||
+        !file.type.includes("png") &&
+        !file.type.includes("svg") &&
+        !file.type.includes("jpeg") &&
         !file.type.includes("gif")
       ) {
         toast.error(errorMessage.invalidImageExtension, {

--- a/src/recoil/atoms/coding-meeting/dateTime.tsx
+++ b/src/recoil/atoms/coding-meeting/dateTime.tsx
@@ -2,7 +2,6 @@ import { Value } from "@/interfaces/calendar"
 import { atom } from "recoil"
 
 export type Time = {
-  range: string
   hour: string
   minute: string
 }
@@ -10,7 +9,6 @@ export type Time = {
 export const StartTime = atom<Time>({
   key: "coding-meeting-start-time-atom",
   default: {
-    range: "",
     hour: "",
     minute: "",
   },
@@ -19,7 +17,6 @@ export const StartTime = atom<Time>({
 export const EndTime = atom<Time>({
   key: "coding-meeting-end-time-atom",
   default: {
-    range: "",
     hour: "",
     minute: "",
   },

--- a/src/util/checkFormValidation.ts
+++ b/src/util/checkFormValidation.ts
@@ -1,0 +1,55 @@
+import { errorMessage } from "@/constants/message"
+import { FieldErrors } from "react-hook-form"
+import { toast } from "react-toastify"
+
+export type BasicFormData = {
+  title: string
+  content: string
+}
+
+const checkFormValidation = async (errors: FieldErrors<BasicFormData>) => {
+  if (errors?.title) {
+    const titleErrorMessage = ((type: typeof errors.title.type) => {
+      switch (type) {
+        case "required":
+          return errorMessage.notitle
+        case "minLength":
+          return errorMessage.underTitleLimit
+        case "maxLength":
+          return errorMessage.overTitleLimit
+      }
+    })(errors.title.type)
+
+    toast.error(titleErrorMessage, {
+      position: "top-center",
+      toastId: "createCodingMeetingTitle",
+    })
+
+    window.scroll({
+      top: 0,
+      behavior: "smooth",
+    })
+
+    return
+  }
+  if (errors?.content) {
+    const contentErrorMessage = ((type: typeof errors.content.type) => {
+      switch (type) {
+        case "required":
+          return errorMessage.noContent
+        case "minLength":
+          return errorMessage.underContentLimit
+        case "maxLength":
+          return errorMessage.overContentLimit
+      }
+    })(errors.content.type)
+
+    toast.error(contentErrorMessage, {
+      position: "top-center",
+      toastId: "createCodingMeetingContent",
+    })
+    return
+  }
+}
+
+export default checkFormValidation

--- a/src/util/getDate.ts
+++ b/src/util/getDate.ts
@@ -181,6 +181,8 @@ const getKorRelativeTime = ({
   return IntlFormatter.format(targetDiff, targetUnit)
 }
 
+const formatDay = (date: string) => dayjs(date).format("YYYY-MM-DD")
+
 const formatDate = ({ date }: dateProps, time: string) =>
   `${dayjs(date).format("YYYY-MM-DD")}T${time}:00`
 
@@ -193,6 +195,7 @@ export {
   getNow,
   getKorRelativeTime,
   getKorDayjs,
+  formatDay,
   formatDate,
 }
 


### PR DESCRIPTION
## 관련 이슈

close: [#214 ](https://github.com/KernelSquare/Frontend/issues/214)

## 개요

> 2차 QA에서 피드백 받은 내용을 반영하였습니다. 

## 상세 내용

### 마이페이지
- 마이페이지 이미지 확장자 제한 오류 수정
- Toast UI Viewer 내용이 많으면 위치를 벗어나는 문제 해결 (Readme.md)

### 개발자 Q&A
- Q&A 페이지 댓글 글자수 제한 반영
- 내 답변 보기 버튼 수정
- Q&A 삭제 시 라우팅 수정
- 답변 입력 부분 placeholder 수정

### 커피챗
- 비회원 조회 시 커피챗 입장하기 버튼 숨기기 
- 커피챗 신청 시 제목 길 경우 알림 
- 커피챗 예약을 한 이후 새로고침 필요
- 커피챗 신청 후 다른 시간으로 다시 신청 시 알림 표시 
- 다른 멘토링이 있을 때 알림 표시 

### 모각코
- 모각코 수정하기 이후에 페이지 새로고침
- 모각코 모집글 time picker UI 수정 
- 모각코 모집글 생성 시 유효성 검사 통과 못하면 버튼 disabled 처리
- 모각코 모집글 본문 글자 수 카운터 컴포넌트 추가 
- 이미 진행중인(마감되지 않은) 모각코가 있을 때 알림 표시 

### 랜딩 페이지
- 랜딩 페이지의 경우 full-screen 사이즈 조정 


