### PR TITLE
fix: 질문 작성 취소 이후 이동 주소 변경

### DIFF
--- a/src/page/askQuestion/components/CancelAskQuestionModal.tsx
+++ b/src/page/askQuestion/components/CancelAskQuestionModal.tsx
@@ -7,6 +7,7 @@ import { useToastUiQuestionEditor } from "@/hooks/editor/useToastuiQuestionEdito
 import { DELETE_IMAGE_LOCAL_STORAGE_KEY } from "@/constants/editor"
 import { useResetRecoilState } from "recoil"
 import { searchTagAtom } from "@/recoil/atoms/tag"
+import { useQueryClient } from "@tanstack/react-query"
 import type { EditMode } from "./AskQuestionPageControl"
 
 interface CancelAskQuestionModalProps {
@@ -19,6 +20,8 @@ function CancelAskQuestionModal({
   editMode,
 }: CancelAskQuestionModalProps) {
   const { replace } = useRouter()
+
+  const queryClient = useQueryClient()
 
   const { cancelQuestionSubmit } = useToastUiQuestionEditor({
     uniqueKey: editMode,
@@ -33,9 +36,13 @@ function CancelAskQuestionModal({
       clearTagSearch()
     } catch (error) {
     } finally {
+      queryClient.invalidateQueries({
+        queryKey: ["question", "list"],
+      })
+
       queueMicrotask(() => {
         editMode === "create"
-          ? replace("/")
+          ? replace(`/qna?page=0`)
           : replace(`/question/${questionId}`)
       })
     }


### PR DESCRIPTION
## 관련 이슈

[#213](https://github.com/KernelSquare/Frontend/issues/213)

## 개요

> 질문 취소 이후 이동 주소 수정

## 상세 내용
- 질문 작성 취소 이후 QnA 페이지로 이동하도록 수정
- 리스트 api 관련 query에 대한 invalidate queries 설정