### PR TITLE
fix: 검수 피드백 반영

### DIFF
--- a/src/components/shared/auth-modal/MyPageGuardModal.tsx
+++ b/src/components/shared/auth-modal/MyPageGuardModal.tsx
@@ -32,7 +32,7 @@ MyPageGuardModal.ModalContent = function AskQuestionModalContent() {
   const { replace } = useRouter()
 
   const onClose = () => {
-    replace("/")
+    replace("/qna")
 
     return
   }

--- a/src/components/shared/auth-modal/UserProfileGuardModal.tsx
+++ b/src/components/shared/auth-modal/UserProfileGuardModal.tsx
@@ -28,7 +28,7 @@ UserProfileGuardModal.ModalContent = function AskQuestionModalContent() {
   const { replace } = useRouter()
 
   const onClose = () => {
-    replace("/")
+    replace("/qna")
 
     return
   }

--- a/src/constants/timeOptions.ts
+++ b/src/constants/timeOptions.ts
@@ -52,6 +52,19 @@ export const PM = [
   "23:30",
 ]
 
-const hours = Array.from({ length: 24 }, (_, i) => i + "")
+const hours = [
+  "00",
+  "01",
+  "02",
+  "03",
+  "04",
+  "05",
+  "06",
+  "07",
+  "08",
+  "09",
+  "10",
+  "11",
+]
 const minutes = ["00", "30"]
 export const timeSelect = { hours, minutes }

--- a/src/page/coding-meetings/create/CreateCodingMeetingPage.tsx
+++ b/src/page/coding-meetings/create/CreateCodingMeetingPage.tsx
@@ -272,7 +272,7 @@ const CreateCodingMeetingPage = ({
     }
   }
 
-  const TItleInputClass = twJoin([
+  const TitleInputClass = twJoin([
     "text-base placeholder:text-base",
     watch("title") &&
       (watch("title")?.length < Limitation.title_limit_under ||
@@ -304,7 +304,7 @@ const CreateCodingMeetingPage = ({
               spellCheck="false"
               autoComplete="off"
               fullWidth
-              className={TItleInputClass}
+              className={TitleInputClass}
               placeholder="제목을 입력해주세요"
               {...register("title", {
                 required: true,

--- a/src/page/coding-meetings/create/hooks/useHandleCreateCodingMeetingTime.tsx
+++ b/src/page/coding-meetings/create/hooks/useHandleCreateCodingMeetingTime.tsx
@@ -21,10 +21,8 @@ const useHandleCreateCodingMeetingTime = () => {
   const formatMinute = (minute: number | string) =>
     String(minute).length === 1 ? "0" + String(minute) : minute + ""
 
-  const formatTime = ({ hour, minute }: Time) => {
-    if (hour && hour.length === 1) hour = "0" + hour
-    return `${hour}:${minute}`
-  }
+  const formatTime = ({ hour, minute }: Time) => `${hour}:${minute}`
+
   const formatByUTC = (time: string) => {
     dayjs.extend(utc)
     return dayjs(`${formattedDay} ${time}`).utc().format().slice(0, -1)

--- a/src/page/coffee-chat/create/CreateCoffeeChatReservationPage.types.ts
+++ b/src/page/coffee-chat/create/CreateCoffeeChatReservationPage.types.ts
@@ -10,6 +10,7 @@ export interface CoffeeChatEditorInitialValues {
 
 export interface CoffeeChatFormData {
   title: string
+  content: string
 }
 
 export type SubmitAskQuestionData = CoffeeChatFormData

--- a/src/page/coffee-chat/create/components/HashTagsSection.tsx
+++ b/src/page/coffee-chat/create/components/HashTagsSection.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef } from "react"
+import { useLayoutEffect, useRef } from "react"
 import CoffeeChatSection from "./CoffeeChatSection"
 import { toast } from "react-toastify"
 import { errorMessage } from "@/constants/message"
@@ -17,6 +17,10 @@ const HashTagsSection = () => {
 
   // 제출된 해시태그
   const [hashtags, setHashtags] = useRecoilState(HashTagList)
+
+  useLayoutEffect(() => {
+    setHashtags([])
+  }, [])
   // 해시태그 추가
   const handleAddHashTags = () => {
     // 빈 값 방지

--- a/src/page/coffee-chat/create/components/MdEditor.tsx
+++ b/src/page/coffee-chat/create/components/MdEditor.tsx
@@ -5,17 +5,20 @@ import { useSetRecoilState } from "recoil"
 import type { Editor } from "@toast-ui/react-editor"
 import type { RefObject } from "react"
 import { coffeeChatEditorLoadedAtomFamily } from "@/recoil/atoms/coffeechatEditor"
+import type { EditorType } from "@toast-ui/editor"
 
 interface EditorProps {
   previous?: string
   editorRef: RefObject<Editor>
   userId: number
+  onChange?: (editorType: EditorType) => void
 }
 
 const MdEditorContainer: React.FC<EditorProps> = ({
   previous,
   editorRef,
   userId,
+  onChange,
 }) => {
   const setLoaded = useSetRecoilState(coffeeChatEditorLoadedAtomFamily(userId))
 
@@ -27,6 +30,7 @@ const MdEditorContainer: React.FC<EditorProps> = ({
           initialValue={previous}
           isImage={false}
           setLoaded={setLoaded}
+          onChange={onChange}
           placeholder="생성할 커피챗에 대해 설명해보세요."
         />
       )}

--- a/src/page/coffee-chat/create/components/ScheduleSection.tsx
+++ b/src/page/coffee-chat/create/components/ScheduleSection.tsx
@@ -5,7 +5,7 @@ import CoffeeChatSection from "./CoffeeChatSection"
 import { DirectionIcons, Icons } from "@/components/icons/Icons"
 import TimeOptions from "./TimeOptions"
 import { AM, PM } from "@/constants/timeOptions"
-import { useEffect, useState } from "react"
+import { useEffect, useLayoutEffect, useState } from "react"
 import { TimeZone } from "../CreateCoffeeChatReservationPage.types"
 import { twJoin } from "tailwind-merge"
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil"
@@ -34,12 +34,18 @@ const ScheduleSection = () => {
   // 캘린더에서 선택된 날짜
   const today = new Date()
   const startDate = new Date(dayjs(today).add(7, "day").format("YYYY-MM-DD"))
-  const date = useRecoilValue(CoffeeChatStartDate)
+  const [date, setDate] = useRecoilState(CoffeeChatStartDate)
   const [selectedDay, setSelectedDay] = useRecoilState(SelectedDate)
-  const timeCount = useRecoilValue(TimeCount)
+  const [timeCount, setTimeCount] = useRecoilState(TimeCount)
 
   // // 오전 or 오후
   const [timeZone, setTimeZone] = useState<TimeZone>(TimeZone.AM)
+
+  useLayoutEffect(() => {
+    setTimeZone(TimeZone.AM)
+    setDate(undefined)
+    setTimeCount(0)
+  }, [])
 
   // 오전, 오후 선택 화살표 스타일
   const ArrowClassName = (disabled: boolean) =>

--- a/src/page/coffee-chat/create/components/TimeOptions.tsx
+++ b/src/page/coffee-chat/create/components/TimeOptions.tsx
@@ -12,13 +12,20 @@ import Button from "@/components/shared/button/Button"
 import { toast } from "react-toastify"
 import { errorMessage } from "@/constants/message"
 import Limitation from "@/constants/limitation"
+import { useLayoutEffect } from "react"
 
 const TimeOptions = ({ date }: TimeOptionsProps) => {
   const selectedDate = useRecoilValue(SelectedDate)
   const [schedulelist, setSchedulelist] = useRecoilState(
     ScheduleListAtomFamily(selectedDate),
   )
-  const timeCount = useRecoilValue(TimeCount)
+  const [timeCount, setTimeCount] = useRecoilState(TimeCount)
+  useLayoutEffect(() => {
+    setSchedulelist({
+      schedule: [],
+    })
+    setTimeCount(0)
+  }, [])
   const handleRegister = (time: string) => {
     if (schedulelist.schedule.includes(time)) {
       setSchedulelist({

--- a/src/page/coffee-chat/detail/CoffeeChatDetailPage.tsx
+++ b/src/page/coffee-chat/detail/CoffeeChatDetailPage.tsx
@@ -22,6 +22,7 @@ function CoffeeChatDetailPage({
         return dateTime.mentee_nickname === user?.nickname
       }) ?? null
     : null
+  console.log("match", matchRoom)
 
   const isMentee =
     !user?.roles.includes("ROLE_MENTOR") ||
@@ -42,7 +43,7 @@ function CoffeeChatDetailPage({
       <CoffeeChatDetailContent content={coffeeChatDetailPayload.content} />
       <Spacing size={32} />
       <div className="w-full flex justify-center items-center">
-        {user && isMentee && (
+        {user && isMentee && matchRoom && (
           <EnterCoffeeChat
             articleTitle={coffeeChatDetailPayload.title}
             roomId={matchRoom ? matchRoom.room_id : null}

--- a/src/page/qna-detail/components/Answers/AnswerContentBox.tsx
+++ b/src/page/qna-detail/components/Answers/AnswerContentBox.tsx
@@ -37,8 +37,7 @@ export interface AnswerFormData {
 
 const AnswerContentBox: React.FC<EditAnswerProps> = ({ answer }) => {
   const editorRef = useRef<Editor>(null)
-  const { handleSubmit, register, setValue, getValues, watch } =
-    useForm<AnswerFormData>()
+  const { handleSubmit, register, setValue, watch } = useForm<AnswerFormData>()
   const { isAnswerEditMode, setIsAnswerEditMode } = useHandleMyAnswer({
     answerId: Number(answer.answer_id),
     questionId: Number(answer.question_id),

--- a/src/page/user-profile/components/introduction/Introduction.tsx
+++ b/src/page/user-profile/components/introduction/Introduction.tsx
@@ -8,6 +8,8 @@ import Button from "@/components/shared/button/Button"
 import UserProfileMenu from "../UserProfileMenu"
 import dynamic from "next/dynamic"
 import { Editor } from "@toast-ui/react-editor"
+import TextCounter from "@/components/shared/TextCounter"
+import Limitation from "@/constants/limitation"
 
 const MdEditor = dynamic(() => import("./MdEditor"), {
   ssr: false,
@@ -30,7 +32,9 @@ function Introduction({ introduction, userId }: IntroductionProps) {
     handleSubmitIntroduction,
     isIntroductionEditMode,
   } = useIntroduction()
-  const { handleSubmit } = useForm<{ introduction: string }>()
+  const { handleSubmit, watch, register, setValue } = useForm<{
+    introduction: string
+  }>()
 
   const onsubmit = () => {
     const introduction = editorRef.current?.getInstance().getMarkdown()
@@ -46,7 +50,14 @@ function Introduction({ introduction, userId }: IntroductionProps) {
               previous={introduction}
               editorRef={editorRef}
               userId={userId!}
+              onChange={() => {
+                setValue(
+                  "introduction",
+                  editorRef.current?.getInstance().getMarkdown() ?? "",
+                )
+              }}
             />
+            <TextCounterBox text={watch("introduction")} />
             <div className="flex justify-center mt-[20px]">
               <Button
                 buttonTheme="third"
@@ -55,10 +66,22 @@ function Introduction({ introduction, userId }: IntroductionProps) {
               >
                 {buttonMessage.cancle}
               </Button>
-              <Button buttonTheme="primary" className="w-[70px]" type="submit">
+              <Button
+                buttonTheme="primary"
+                className="w-[70px] disabled:bg-colorsGray disabled:text-colorsDarkGray"
+                type="submit"
+                disabled={
+                  !watch("introduction") ||
+                  watch("introduction").length <
+                    Limitation.introduction_limit_under ||
+                  watch("introduction").length >
+                    Limitation.introduction_limit_over
+                }
+              >
                 {buttonMessage.save}
               </Button>
             </div>
+            <input hidden className="hidden" {...register("introduction")} />
           </form>
         </div>{" "}
       </UserProfileMenu.MenuContentWrapper>
@@ -77,3 +100,19 @@ function Introduction({ introduction, userId }: IntroductionProps) {
 }
 
 export default Introduction
+
+type TextCounterBoxProps = {
+  text: string | undefined
+}
+
+const TextCounterBox = ({ text }: TextCounterBoxProps) => {
+  if (!text) return
+  return (
+    <TextCounter
+      text={text ?? ""}
+      min={Limitation.introduction_limit_under}
+      max={Limitation.introduction_limit_over}
+      className="text-lg block text-right h-5 py-2 font-light"
+    />
+  )
+}

--- a/src/page/user-profile/components/introduction/MdEditor.tsx
+++ b/src/page/user-profile/components/introduction/MdEditor.tsx
@@ -5,17 +5,20 @@ import { useSetRecoilState } from "recoil"
 import { introductionEditorLoadedAtomFamily } from "@/recoil/atoms/introductionEditor"
 import type { Editor } from "@toast-ui/react-editor"
 import type { RefObject } from "react"
+import type { EditorType } from "@toast-ui/editor"
 
 interface EditorProps {
   previous?: string
   editorRef: RefObject<Editor>
   userId: number
+  onChange?: (editorType: EditorType) => void
 }
 
 const MdEditorContainer: React.FC<EditorProps> = ({
   previous,
   editorRef,
   userId,
+  onChange,
 }) => {
   const setLoaded = useSetRecoilState(
     introductionEditorLoadedAtomFamily(userId),
@@ -28,6 +31,7 @@ const MdEditorContainer: React.FC<EditorProps> = ({
           ref={editorRef}
           initialValue={previous}
           isImage={false}
+          onChange={onChange}
           setLoaded={setLoaded}
           placeholder="자기소개를 작성해주세요"
         />


### PR DESCRIPTION
## 관련 이슈

[#214 ](https://github.com/KernelSquare/Frontend/issues/214)

## 개요

> 금일 작성된 검수 피드백 사항을 반영하여 수정하였습니다.

## 상세 내용

- 마이페이지 자기소개글 글자 수 카운터 컴포넌트 추가 및 disabled 처리
- 로그인하지 않고 접속할 경우 노출되는 접근 제한 모달의 '홈 버튼' 클릭 시 랜딩 페이지가 아닌 로그인 버튼이 보이는 qna 목록 페이지로 이동하도록 설정
- 커피챗 생성 시 본문 내용 카운터 컴포넌트 추가 및 disabled 처리 
- 예약하지 않은 커피챗 상세 페이지에서는 커피챗 입장 버튼 노출 막기
- 커피챗 등록글 생성하기 time의 값이 유지되는 오류 수정
- time picker에서 시간 한 자리 수일 경우 앞에 '0' 붙이기
