### PR TITLE
fix: 커피챗, search 페이지네이션 수정

### DIFF
--- a/src/components/shared/pagination/Pagination.tsx
+++ b/src/components/shared/pagination/Pagination.tsx
@@ -29,17 +29,13 @@ interface PaginationProps
     | "breakClassName"
     | "breakLinkClassName"
     | "breakLabel"
+    | "previousLabel"
+    | "nextLabel"
   > {
   onSkip?: (args: { type: "prevSkip" | "nextSkip"; pageCount: number }) => void
 }
 
-export function Pagination({
-  previousLabel,
-  nextLabel,
-  onClick,
-  onSkip,
-  ...props
-}: PaginationProps) {
+export function Pagination({ onClick, onSkip, ...props }: PaginationProps) {
   const pageButtonWrapperClassNames = (
     type: "page" | "active" | "next" | "prev" | "break",
   ) =>

--- a/src/components/shared/qna/QnAList.tsx
+++ b/src/components/shared/qna/QnAList.tsx
@@ -23,24 +23,55 @@ function QnAList({ questions, keyword, isSearch }: QnAListProps) {
 
   return (
     <div className="py-4 w-[calc(100%-12px)] sm:w-[calc(100%-22px)] lg:w-[calc(100%-42px)] mx-auto">
-      <ul className="flex flex-col gap-8">
+      <ul className="flex flex-col gap-4">
         {questions.question_list.map((question) => {
           return <OneQnA question={question} key={question.id} />
         })}
       </ul>
       <Spacing size={32} />
       <Pagination
-        previousLabel="이전"
-        nextLabel="다음"
         disabledClassName="hidden"
         forcePage={Number(page)}
         pageCount={questions.pagination.total_page}
         onPageChange={({ selected }) => {
-          push(
-            isSearch
-              ? `?page=${selected}&keyword=${keyword}`
-              : `?page=${selected}`,
-          )
+          const searchParams = new URLSearchParams()
+          if (isSearch) {
+            searchParams.set("keyword", keyword)
+          }
+          searchParams.set("page", `${selected}`)
+
+          push(`?${searchParams.toString()}`)
+        }}
+        onSkip={({ type, pageCount }) => {
+          const searchParams = new URLSearchParams()
+
+          const pageNumber = Number(page)
+
+          if (isSearch) {
+            searchParams.set("keyword", keyword)
+          }
+
+          if (type === "prevSkip") {
+            if (pageCount > 10 && pageNumber - 10 >= 0) {
+              searchParams.set("page", `${pageNumber - 10}`)
+
+              push(`?${searchParams.toString()}`)
+
+              return
+            }
+
+            return
+          }
+
+          if (type === "nextSkip") {
+            if (pageCount > 10 && pageCount - 1 - pageNumber >= 10) {
+              searchParams.set("page", `${pageNumber + 10}`)
+
+              push(`?${searchParams.toString()}`)
+            }
+
+            return
+          }
         }}
       />
     </div>

--- a/src/page/coffee-chat/main/CoffeeChatListContainer.tsx
+++ b/src/page/coffee-chat/main/CoffeeChatListContainer.tsx
@@ -65,13 +65,38 @@ function CoffeeChatListContainer() {
     const Portal = portalContainer
       ? createPortal(
           <Pagination
-            previousLabel="이전"
-            nextLabel="다음"
             disabledClassName="hidden"
             forcePage={Number(page)}
             pageCount={coffeeChatList!.pagination.total_page}
             onPageChange={({ selected }) => {
               push(`/chat?page=${selected}`)
+            }}
+            onSkip={({ type, pageCount }) => {
+              const searchParams = new URLSearchParams()
+
+              const pageNumber = Number(page)
+
+              if (type === "prevSkip") {
+                if (pageCount > 10 && pageNumber - 10 >= 0) {
+                  searchParams.set("page", `${pageNumber - 10}`)
+
+                  push(`/chat?${searchParams.toString()}`)
+
+                  return
+                }
+
+                return
+              }
+
+              if (type === "nextSkip") {
+                if (pageCount > 10 && pageCount - 1 - pageNumber >= 10) {
+                  searchParams.set("page", `${pageNumber + 10}`)
+
+                  push(`/chat?${searchParams.toString()}`)
+                }
+
+                return
+              }
             }}
           />,
           portalContainer,


### PR DESCRIPTION
## 관련 이슈

[#213](https://github.com/KernelSquare/Frontend/issues/213)

## 개요

> 수정된 페이지네이션 적용

## 상세 내용

- 커피챗 리스트, 검색 페이지에서도 수정된 페이지네이션이 적용될 수 있도록 수정
- 페이지네이션 label prop 제거
- 검색 페이지 리스트에도 다른 리스트 페이지에서와 동일한 gap을 유지하도록 수정
