### PR TITLE
fix: 깃허브 로그인 에러 페이지 수정

### DIFF
--- a/src/app/oauth/github/page.tsx
+++ b/src/app/oauth/github/page.tsx
@@ -27,12 +27,7 @@ export default function OAuthGithub({ searchParams }: OAuthGihubProps) {
     ? Buffer.from(loginResponseCookie, "base64").toString("utf-8")
     : ""
 
-  const error = searchParams?.errorCode
-    ? {
-        errorCode: Number(searchParams.errorCode),
-        errorMessage: searchParams.errorMessage,
-      }
-    : null
+  const error = parseErrorFromQs({ searchParams })
 
   if (user) {
     return loginResponseCookie ? (
@@ -43,12 +38,7 @@ export default function OAuthGithub({ searchParams }: OAuthGihubProps) {
   }
 
   if (error) {
-    return (
-      <OAuthGithubError
-        errorCode={error.errorCode}
-        errorMessage={error.errorMessage}
-      />
-    )
+    return <OAuthGithubError errorCode={error.errorCode} />
   }
 
   if (!decodedLoginResponseCookie) {
@@ -56,4 +46,36 @@ export default function OAuthGithub({ searchParams }: OAuthGihubProps) {
   }
 
   return <OAuthGithubSuccess decodedCookie={decodedLoginResponseCookie} />
+}
+
+function parseErrorFromQs({
+  searchParams,
+}: Pick<OAuthGihubProps, "searchParams">) {
+  const knownErrorCode = [1106, 9999]
+
+  if (searchParams?.errorCode) {
+    const errorCode = Number(searchParams.errorCode)
+
+    if (
+      Number.isNaN(errorCode) ||
+      errorCode < 0 ||
+      searchParams.errorCode.includes(".")
+    ) {
+      return {
+        errorCode: 9999,
+      }
+    }
+
+    if (!knownErrorCode.includes(errorCode)) {
+      return {
+        errorCode: 9999,
+      }
+    }
+
+    return {
+      errorCode,
+    }
+  }
+
+  return null
 }

--- a/src/page/oauth/github/error/OAuthGithubError.tsx
+++ b/src/page/oauth/github/error/OAuthGithubError.tsx
@@ -6,19 +6,22 @@ interface OAuthGithubErrorProps {
   errorMessage?: string
 }
 
-function OAuthGithubError({ errorCode, errorMessage }: OAuthGithubErrorProps) {
+const errorMessage = {
+  1106: "깃허브 설정에서 이메일 정보를 허용해 주세요",
+  9999: "깃허브 로그인에 실패하였습니다",
+} as Record<number, string>
+
+function OAuthGithubError({ errorCode }: OAuthGithubErrorProps) {
   return (
     <OAuthGithubErrorWrapper>
       <div>
         <OAuthGithubErrorField
           fieldName="code"
-          payload={<span>{errorCode ?? "unknown"}</span>}
+          payload={<span>{errorCode}</span>}
         />
         <OAuthGithubErrorField
           fieldName="message"
-          payload={
-            <span>{errorMessage ?? "깃헙 로그인 중 에러가 발생했습니다"}</span>
-          }
+          payload={<span>{errorMessage[errorCode]}</span>}
         />
       </div>
     </OAuthGithubErrorWrapper>

--- a/src/page/oauth/github/error/OAuthGithubErrorWrapper.tsx
+++ b/src/page/oauth/github/error/OAuthGithubErrorWrapper.tsx
@@ -17,7 +17,7 @@ function OAuthGithubErrorWrapper({ children }: OAuthGithubErrorWrapperProps) {
               <GithubIcon />
             </div>
             <h3 className="font-bold text-secondary text-xl">
-              Github Login Error
+              Github Login Fail
             </h3>
           </section>
           <section className="w-full">{children}</section>


### PR DESCRIPTION
## 관련 이슈

[#306](https://github.com/KernelSquare/Frontend/issues/306)

## 개요

> 깃허브 소셜 로그인 에러 페이지 수정

## 상세 내용

- Github Login Error -> Github Login Fail 로 제목 수정
- errorCode 로 분류하여 에러 메시지를 보여주도록 수정