### PR TITLE
[fix] 모각코 상세 url

### DIFF
--- a/src/page/coding-meetings/util/cm-token.ts
+++ b/src/page/coding-meetings/util/cm-token.ts
@@ -1,16 +1,7 @@
 export function serializeCmToken(cmToken: string) {
-  const serializedCmToken = cmToken.replace(/^cm_/g, "")
-  const lowerCaseFirstChar = serializedCmToken[0].toLowerCase()
-
-  return serializedCmToken.replace(/^[A-Z]/g, lowerCaseFirstChar)
+  return cmToken.replace(/^cm_/g, "cm-")
 }
 
 export function deSerializeCmToken(serializedCmToken: string) {
-  const upperCaseFirstChar = serializedCmToken[0].toUpperCase()
-  const deSerializeCmToken = `cm_${serializedCmToken.replace(
-    /^[a-z]/g,
-    upperCaseFirstChar,
-  )}`
-
-  return deSerializeCmToken
+  return `${serializedCmToken.replace(/^cm\-/g, "cm_")}`
 }


### PR DESCRIPTION

## 상세 내용
- 백엔드 모각코 토큰이 cm_이후 소문자나 숫자로도 시작하는 경우가 있는 것 같아 cm- 로 시작하는 것으로 수정
- 메타데이터 생성시 실패하지 않고 데이터를 가져온 이후 og가 표시가 되지 않는 이유는 좀 더 확인해봐야 될 것 같음 (fallback 상황에서는 og 표시되지만, 없는 페이지라 의미가 없음)
