### PR TITLE
SEO 관련 수정

### DIFF
--- a/src/app/chat/create/page.tsx
+++ b/src/app/chat/create/page.tsx
@@ -8,6 +8,9 @@ import { notFound } from "next/navigation"
 export const metadata: Metadata = {
   title: `커피챗 생성`,
   description: `커피챗 생성 페이지`,
+  robots: {
+    index: false,
+  },
   openGraph: {
     title: `커피챗 생성 - 커널스퀘어`,
     description: `커피챗 생성 페이지`,

--- a/src/app/chat/room/[id]/page.tsx
+++ b/src/app/chat/room/[id]/page.tsx
@@ -38,6 +38,9 @@ interface CoffeeChatRoomProps {
 export const metadata: Metadata = {
   title: `커피챗 채팅`,
   description: `커피챗 채팅 페이지`,
+  robots: {
+    index: false,
+  },
   openGraph: {
     title: `커피챗 채팅`,
     description: `커피챗 채팅 페이지`,

--- a/src/app/chat/u/[id]/page.tsx
+++ b/src/app/chat/u/[id]/page.tsx
@@ -12,6 +12,9 @@ export interface CoffeeChatUpdatePageProps {
 export const metadata: Metadata = {
   title: `커피챗 수정`,
   description: `커피챗 수정 페이지`,
+  robots: {
+    index: false,
+  },
   openGraph: {
     title: `커피챗 수정 - 커널스퀘어`,
     description: `커피챗 수정 페이지`,

--- a/src/app/coding-meetings/create/page.tsx
+++ b/src/app/coding-meetings/create/page.tsx
@@ -9,6 +9,9 @@ import { notFound } from "next/navigation"
 export const metadata: Metadata = {
   title: `모각코 생성`,
   description: `모각코 생성 페이지`,
+  robots: {
+    index: false,
+  },
   openGraph: {
     title: `모각코 생성 - 커널스퀘어`,
     description: `모각코 생성 페이지`,

--- a/src/app/coding-meetings/post/[token]/page.tsx
+++ b/src/app/coding-meetings/post/[token]/page.tsx
@@ -17,6 +17,9 @@ export interface UpdateCodingMeetingsPageProps {
 export const metadata: Metadata = {
   title: "모각코 수정",
   description: "모각코 수정 페이지",
+  robots: {
+    index: false,
+  },
   openGraph: {
     title: `모각코 수정 - 커널스퀘어`,
     description: `모각코 수정 페이지`,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,6 +23,16 @@ export const metadata: Metadata = {
     template: "%s - 커널스퀘어",
     default: "커널스퀘어",
   },
+  verification:
+    process.env.NEXT_PUBLIC_GA_ACTIVE === "enabled"
+      ? {
+          google: process.env.NEXT_PUBLIC_GOOGLE_VERIFICATION,
+          other: {
+            "naver-site-verification":
+              process.env.NEXT_PUBLIC_NAVER_VERIFICATION!,
+          },
+        }
+      : undefined,
   openGraph: {
     images: {
       url: "/og.png",

--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -4,6 +4,9 @@ import { Metadata } from "next"
 export const metadata: Metadata = {
   title: "알림 조회",
   description: "개인 알림 조회",
+  robots: {
+    index: false,
+  },
   openGraph: {
     title: "알림 조회 - 커널스퀘어",
     description: "개인 알림 조회",

--- a/src/app/oauth/github/page.tsx
+++ b/src/app/oauth/github/page.tsx
@@ -17,6 +17,9 @@ interface OAuthGihubProps {
 export const metadata: Metadata = {
   title: "github 소셜로그인",
   description: "github 소셜로그인",
+  robots: {
+    index: false,
+  },
 }
 
 export default function OAuthGithub({ searchParams }: OAuthGihubProps) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,16 +5,6 @@ import { Metadata } from "next"
 export const metadata: Metadata = {
   title: `${layoutMeta["/"].title} - 커널스퀘어`,
   description: `${layoutMeta["/"].description}`,
-  verification:
-    process.env.NEXT_PUBLIC_GA_ACTIVE === "enabled"
-      ? {
-          google: process.env.NEXT_PUBLIC_GOOGLE_VERIFICATION,
-          other: {
-            "naver-site-verification":
-              process.env.NEXT_PUBLIC_NAVER_VERIFICATION!,
-          },
-        }
-      : undefined,
   openGraph: {
     title: `${layoutMeta["/"].title} - 커널스퀘어`,
     description: `${layoutMeta["/"].description}`,

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -25,6 +25,9 @@ export async function generateMetadata({
   const fallbackMetadata: Metadata = {
     title: "유저 프로필",
     description: "로그인 후 유저 프로필 페이지를 볼 수 있습니다.",
+    robots: {
+      index: false,
+    },
     openGraph: {
       title: "유저 프로필",
       description: "로그인 후 유저 프로필 페이지를 볼 수 있습니다.",
@@ -61,6 +64,9 @@ export async function generateMetadata({
     return {
       title: `${nickname} : 프로필`,
       description: userIntroduction,
+      robots: {
+        index: false,
+      },
       openGraph: {
         title: `${nickname} : 프로필 - 커널스퀘어`,
         description: userIntroduction,

--- a/src/app/question/page.tsx
+++ b/src/app/question/page.tsx
@@ -9,6 +9,9 @@ export const revalidate = 0
 export const metadata: Metadata = {
   title: "질문 작성",
   description: "질문 작성 페이지",
+  robots: {
+    index: false,
+  },
 }
 
 // dynamic import (CSR)

--- a/src/app/question/u/[id]/page.tsx
+++ b/src/app/question/u/[id]/page.tsx
@@ -19,6 +19,9 @@ export interface QuestionUpdatePageProps {
 export const metadata: Metadata = {
   title: `${layoutMeta["updateQuestion"].title}`,
   description: `${layoutMeta["updateQuestion"].description}`,
+  robots: {
+    index: false,
+  },
 }
 
 function isValidPageProps({ params }: QuestionUpdatePageProps) {

--- a/src/app/robots.txt
+++ b/src/app/robots.txt
@@ -1,5 +1,14 @@
 User-Agent: *
 Disallow: /signup
 Disallow: /profile/
+Disallow: /question$
+Disallow: /question/u/
+Disallow: /chat/create
+Disallow: /chat/room/
+Disallow: /chat/u/
+Disallow: /coding-meetings/create
+Disallow: /coding-meetings/post/
+Disallow: /notification
+Disallow: /oauth/
 
 Sitemap: https://kernelsquare.live/sitemap.xml


### PR DESCRIPTION
## 관련 이슈

close: [#327](https://github.com/KernelSquare/Frontend/issues/327)

## 개요

> SEO robots.txt, robots / verification 메타태그 수정

## 상세 내용
 - verification 메타태그를 layout 에 설정하여 페이지에 전역적으로 적용될 수 있도록 수정
 - robots.txt
 권한이 필요해서 로그인 하지 않았을 때 접근이 되지 않는 페이지 Disallow 설정 (크롤링 예산에 긍정적인 영향을 주어 한번에 보다 많은 사이트를 수집할 수 있도록 하는 효과를 기대)
 - robots meta
 권한이 필요해서 로그인 하지 않았을 때 접근이 되지 않는 페이지가 검색엔진에 노출되지 않도록(색인되지 않도록) noindex 설정