### PR TITLE
알림 리스트 스타일 수정, msw

### DIFF
--- a/src/components/layout/header/alerm/Alerm.tsx
+++ b/src/components/layout/header/alerm/Alerm.tsx
@@ -126,12 +126,9 @@ AlermList.Alerm = function AlermListAlerm({
         onClick={onLink}
       >
         <AlermList.AlermWrapper>
-          <AlermList.TypeTag type={alerm.alert_type} />
+          <AlermList.TypeTag type={"QUESTION_REPLY"} />
           <div className="text-sm font-medium text-secondary">
-            <span
-              className="max-w-[28%] inline-block align-top overflow-hidden font-bold text-ellipsis"
-              style={{ textWrap: "nowrap" }}
-            >
+            <span className="max-w-[28%] inline-block whitespace-nowrap align-top overflow-hidden font-bold text-ellipsis">
               {questionReplyAlerm.payload.questionTitle}
             </span>
             <span> 글에 </span>
@@ -156,12 +153,15 @@ AlermList.Alerm = function AlermListAlerm({
         onClick={onLink}
       >
         <AlermList.AlermWrapper>
+          <AlermList.TypeTag type={"RANK_ANSWER"} />
           <div className="text-sm font-medium text-secondary">
-            <span className="max-w-[28%] inline-block align-top overflow-hidden font-bold text-ellipsis">
+            <span className="text-[#214B8F] max-w-[28%] inline-block whitespace-nowrap align-top overflow-hidden font-bold text-ellipsis">
               {rankAnswerAlerm.payload.questionTitle}
             </span>
             <span> 글에 작성하신 답변이 </span>
-            <span className="font-bold">{rankAnswerAlerm.payload.rank}등</span>
+            <span className="text-[#214B8F] font-bold">
+              {rankAnswerAlerm.payload.rank}등
+            </span>
             <span> 답변이 되었습니다.</span>
           </div>
           <AlermList.AlermTime time={rankAnswerAlerm.send_time} />
@@ -174,13 +174,14 @@ AlermList.Alerm = function AlermListAlerm({
     const coffeeChatRequestAlerm = alerm as SSEMessage<"COFFEE_CHAT_REQUEST">
 
     return (
-      <AlermList.AlermWrapper className="bg-white hover:bg-colorsLightGray transition-colors duration-200 text-secondary">
+      <AlermList.AlermWrapper className="bg-white hover:bg-colorsLightGray transition-colors duration-200 text-secondary text-sm">
+        <AlermList.TypeTag type={"COFFEE_CHAT_REQUEST"} />
         <div>
           <Link
             href={`/profile/${coffeeChatRequestAlerm.payload.senderId}`}
             onClick={onLink}
           >
-            <span className="text-sm font-bold underline underline-offset-4">
+            <span className="text-[#D9B48F] text-sm font-bold underline underline-offset-4">
               {coffeeChatRequestAlerm.payload.sender}
             </span>
           </Link>
@@ -215,10 +216,15 @@ AlermList.TypeTag = function AlermListTypeStatusTag({
 }: {
   type: AlertType
 }) {
+  const classNames = twMerge([
+    `w-fit h-fit shrink-0 text-xs px-2 py-1 rounded-full text-white`,
+    type === "QUESTION_REPLY" && "bg-primary",
+    type === "RANK_ANSWER" && "bg-[#214B8F]",
+    type === "COFFEE_CHAT_REQUEST" && "bg-[#D9B48F]",
+  ])
+
   return (
-    <div
-      className={`w-fit h-fit shrink-0 text-xs px-2 py-1 rounded-full bg-primary text-white`}
-    >
+    <div className={classNames}>
       {type === "QUESTION_REPLY"
         ? "질문 답변"
         : type === "RANK_ANSWER"

--- a/src/mocks/handler/index.ts
+++ b/src/mocks/handler/index.ts
@@ -3,6 +3,7 @@ import { authHandler } from "./auth"
 import { codingMeetingHandler } from "./coding-meeting"
 import { coffeeChatHandler } from "./coffee-chat"
 import { memberHandler } from "./member"
+import { mockNotificationApi } from "./notification"
 import { questionHandler } from "./question"
 import { searchHandler } from "./search"
 import { techTagsHandler } from "./techs"
@@ -18,4 +19,5 @@ export const mswHandler = [
   ...searchHandler,
   ...techTagsHandler,
   ...codingMeetingHandler,
+  ...mockNotificationApi,
 ]

--- a/src/mocks/handler/notification/get-alerts.ts
+++ b/src/mocks/handler/notification/get-alerts.ts
@@ -1,0 +1,135 @@
+import { GetAlertListResponse } from "@/interfaces/dto/sse/get-alret-list"
+import { mockUsers } from "@/mocks/db/user"
+import { RouteMap } from "@/service/route-map"
+import { HttpStatusCode } from "axios"
+import { DefaultBodyType, HttpResponse, PathParams, http } from "msw"
+
+export const getAlerts = http.get<
+  PathParams,
+  DefaultBodyType,
+  GetAlertListResponse
+>(`${process.env.NEXT_PUBLIC_SSE}${RouteMap.alert.getAlertList}`, async () => {
+  return HttpResponse.json(
+    {
+      code: 6140,
+      msg: "나의 알림 모두 조회 성공",
+      data: {
+        personal_alert_list: [
+          {
+            id: "alt_w258JhuskFjRwq2n",
+            alert_type: "QUESTION_REPLY",
+            recipient: "ryan",
+            send_time: "2024-03-26T11:01:45Z",
+            payload: {
+              questionTitle: "SSE 알림 테스트 입니다",
+              sender: "X테스트X",
+              questionId: "359",
+            },
+          },
+          {
+            id: "alt_ybgeUI54Cw67ykkX",
+            alert_type: "QUESTION_REPLY",
+            recipient: "ryan",
+            send_time: "2024-03-26T13:12:38Z",
+            payload: {
+              questionTitle: "SSE 알림 테스트 입니다",
+              sender: "자바덕",
+              questionId: "359",
+            },
+          },
+          {
+            id: "alt_Zm4xnaCjkto4sUxv",
+            alert_type: "QUESTION_REPLY",
+            recipient: "ryan",
+            send_time: "2024-03-26T13:14:18Z",
+            payload: {
+              questionTitle: "SSE 알림 테스트 입니다",
+              sender: "자바덕",
+              questionId: "359",
+            },
+          },
+          {
+            id: "alt_nyYBC3cLvbSrB5IM",
+            alert_type: "QUESTION_REPLY",
+            recipient: "ryan",
+            send_time: "2024-03-26T13:16:00Z",
+            payload: {
+              questionTitle: "SSE 알림 테스트 입니다",
+              sender: "자바덕",
+              questionId: "359",
+            },
+          },
+          {
+            id: "alt_EiFj23yFFDre3pxx",
+            alert_type: "QUESTION_REPLY",
+            recipient: "ryan",
+            send_time: "2024-03-26T13:21:18Z",
+            payload: {
+              questionTitle: "SSE 알림 테스트 입니다",
+              sender: "자바덕",
+              questionId: "359",
+            },
+          },
+          {
+            id: "alt_R3cWFkw9pnmukm4R",
+            alert_type: "QUESTION_REPLY",
+            recipient: "ryan",
+            send_time: "2024-03-26T13:23:30Z",
+            payload: {
+              questionTitle: "SSE 알림 테스트 입니다",
+              sender: "자바덕",
+              questionId: "359",
+            },
+          },
+          {
+            id: "alt_0W45KVIYCrpWBE8s",
+            alert_type: "QUESTION_REPLY",
+            recipient: "ryan",
+            send_time: "2024-03-26T14:05:48Z",
+            payload: {
+              questionTitle: "SSE 알림 테스트 입니다",
+              sender: "자바덕",
+              questionId: "359",
+            },
+          },
+          {
+            id: "alt_eSJI6yIg3V8Ep0mR",
+            alert_type: "RANK_ANSWER",
+            recipient: "ryan",
+            send_time: "2024-04-03T17:00:03Z",
+            payload: {
+              questionTitle: "SSE 알림 확인용 게시글입니다.",
+              rank: "1",
+              questionId: "365",
+            },
+          },
+          {
+            id: "alt_2fSOfBqER5xuwrqp",
+            alert_type: "RANK_ANSWER",
+            recipient: "ryan",
+            send_time: "2024-04-03T17:00:03Z",
+            payload: {
+              questionTitle:
+                "Blue Green 배포에 대하여 최대한 상세하게 답변해주세요.",
+              rank: "1",
+              questionId: "368",
+            },
+          },
+          {
+            id: "alt_2fSOfBqAQ1xuwrqp",
+            alert_type: "COFFEE_CHAT_REQUEST",
+            recipient: "ryan",
+            send_time: "2024-04-03T17:01:00Z",
+            payload: {
+              sender: mockUsers[2].nickname,
+              senderId: mockUsers[2].id,
+            },
+          },
+        ],
+      },
+    },
+    {
+      status: HttpStatusCode.Ok,
+    },
+  )
+})

--- a/src/mocks/handler/notification/index.ts
+++ b/src/mocks/handler/notification/index.ts
@@ -1,0 +1,3 @@
+import { getAlerts } from "./get-alerts"
+
+export const mockNotificationApi = [getAlerts]


### PR DESCRIPTION
## 관련 이슈

[#329](https://github.com/KernelSquare/Frontend/issues/329)

## 개요

> 알람 배지 스타일 수정, 말줄임표가 적용되도록 css 수정

## 상세 내용

- 알림 목록 api에 대해 간단한 msw 핸들러 적용
- 알람 배지 스타일 수정, 말줄임표가 적용되도록 css 수정
- 답변랭크, 커피챗 요청 강조 색상 css 수정
