### PR TITLE
커피챗 소개글 유효성 검사 수정, 커피챗 상세 캘린더 css개선

### DIFF
--- a/src/constants/limitation.ts
+++ b/src/constants/limitation.ts
@@ -30,6 +30,8 @@ const Limitation = {
   mentoring_time: 10,
   title_limit_under: 5,
   title_limit_over: 100,
+  chat_content_min_length: 10,
+  chat_content_max_length: 1000,
   chat_introduction_limit_under: 10,
   chat_introduction_limit_over: 150,
   content_limit_under: 10,

--- a/src/constants/message/validation.ts
+++ b/src/constants/message/validation.ts
@@ -10,6 +10,7 @@ export const validationMessage = {
   noTime: "정확한 시간대를 설정해주세요",
   noLocation: "모임 위치를 설정해주세요",
   noHeadCnt: "모임 인원을 설정해주세요",
+  chatContentLength: `소개글은 최소 ${Limitation.chat_content_min_length}자 이상 ${Limitation.chat_content_max_length}자 이하이어야 합니다.`,
   underContentLimit: `본문 내용은 최소 ${Limitation.content_limit_under}자 이상이어야 합니다.`,
   overContentLimit: `본문 내용은 최대 ${Limitation.content_limit_over}자 이하이어야 합니다.`,
   underAnswerLimit: `댓글 내용은 최소 ${Limitation.answer_limit_under}자 이상이어야 합니다.`,

--- a/src/page/coffee-chat/create/components/sections/content/ContentSection.tsx
+++ b/src/page/coffee-chat/create/components/sections/content/ContentSection.tsx
@@ -33,8 +33,8 @@ function CoffeeChatContentSection({ control }: CoffeeChatContentSectionProps) {
               </div>
               <TextCounter
                 text={field.value}
-                min={Limitation.content_limit_under}
-                max={Limitation.content_limit_over}
+                min={Limitation.chat_content_min_length}
+                max={Limitation.chat_content_max_length}
                 className="text-lg block text-right h-2 mr-5"
               />
             </div>

--- a/src/page/coffee-chat/create/controls/rules/chat-content-rules.ts
+++ b/src/page/coffee-chat/create/controls/rules/chat-content-rules.ts
@@ -11,11 +11,11 @@ type ChatContentRules = Omit<
 export const chatContentRules: ChatContentRules = {
   required: validationMessage.noContent,
   minLength: {
-    value: Limitation.content_limit_under,
-    message: validationMessage.underContentLimit,
+    value: Limitation.chat_content_min_length,
+    message: validationMessage.chatContentLength,
   },
   maxLength: {
-    value: Limitation.content_limit_over,
-    message: validationMessage.overContentLimit,
+    value: Limitation.chat_content_max_length,
+    message: validationMessage.chatContentLength,
   },
 }

--- a/src/styles/react-calendar/Base.css
+++ b/src/styles/react-calendar/Base.css
@@ -67,6 +67,11 @@
   color: white;
 }
 
+.react-calendar__tile--active:enabled:hover,
+.react-calendar__tile--active:enabled:focus {
+  background: #00c471;
+}
+
 .react-calendar__tile--range {
   background: #f8f8fa;
   color: #00c471;
@@ -99,7 +104,6 @@
   .react-calendar__tile:enabled:focus {
     background: #00c47133;
     color: #00c471;
-    border-radius: 6px;
   }
 
   .react-calendar__tile--now:enabled:hover,
@@ -114,7 +118,6 @@
   .react-calendar__tile--hasActive:enabled:focus {
     background: #f8f8fa;
     border-color: #00c471;
-    border: 1px;
   }
 
   .react-calendar__tile--active:enabled:hover,
@@ -129,6 +132,12 @@
 }
 
 @media (hover: none) {
+  .react-calendar__tile--active:hover,
+  .react-calendar__tile--active:focus {
+    background: #00c471;
+    color: white;
+  }
+
   .react-calendar__tile--active:enabled:hover,
   .react-calendar__tile--active:enabled:focus {
     background: #00c471;

--- a/src/styles/react-calendar/CoffeeChatTile.css
+++ b/src/styles/react-calendar/CoffeeChatTile.css
@@ -1,19 +1,16 @@
 .react-calendar__tile:not(.disabled).reservation-possible {
   background: #fbf8ce;
-  border-radius: 6px;
 }
 
 .react-calendar__tile:not(.disabled).reservation-confirm {
   background: lightgray;
   color: #fff;
   font-weight: bold;
-  border-radius: 6px;
 }
 
 .react-calendar__tile:not(.disabled).mentoring {
   background: #00c471;
   color: #fff;
-  border-radius: 6px;
 }
 .react-calendar__tile--active.mentoring abbr {
   color: #ffff80;


### PR DESCRIPTION
## 관련 이슈

#342

## 개요

> 소개글 유효성 검사 수정, react 캘린더 타일 css 수정

## 상세 내용

- 소개글이 1000자 이상일 경우 에러 응답 확인되어 수정 함 (10자이상 1000자 이하)
- 휴대폰에서 UX를 개선하기 위해 커피챗 상세 페이지의 캘린더 css 개선
  - focus 된 타일 배경과 active상태의 타일 배경을 일치시킴
