### PR TITLE
fix: 액션 버튼 클릭시 창 열리지 않음

### DIFF
--- a/src/app/api/send-fcm/route.ts
+++ b/src/app/api/send-fcm/route.ts
@@ -70,7 +70,32 @@ export async function POST(request: NextRequest) {
               notification: {
                 ...notificationPayload,
               },
+              webpush: {
+                notification: {
+                  title: notificationPayload.title,
+                  body: notificationPayload.body,
+                  image: notificationPayload.imageUrl,
+                  badge:
+                    process.env.NEXT_PUBLIC_SITE_URL +
+                    "/icons/outline-badge-icon.png",
+                  icon: process.env.NEXT_PUBLIC_SITE_URL + "/icon.png",
+                  actions: [
+                    {
+                      action: "answer:view",
+                      title: "글 보기",
+                    },
+                    {
+                      action: "answer:close",
+                      title: "알림 닫기",
+                    },
+                  ],
+                },
+                fcmOptions: {
+                  link: `${process.env.NEXT_PUBLIC_SITE_URL}/question/${postId}`,
+                },
+              },
               data: {
+                type: "answer",
                 postId: `${postId}`,
               },
             })

--- a/src/interfaces/push/push-action.ts
+++ b/src/interfaces/push/push-action.ts
@@ -1,0 +1,8 @@
+import { NotificationType } from "./push-type"
+
+export interface NotificationAction {
+  action: NotificationType
+  title: string
+}
+
+export type NotificationActions = NotificationAction[]

--- a/src/interfaces/push/push-notification.ts
+++ b/src/interfaces/push/push-notification.ts
@@ -1,0 +1,24 @@
+import { FcmNotificationData, NotificationType } from "../dto/fcm/send-fcm.dto"
+import { NotificationActions } from "./push-action"
+
+export interface AppPushNotification extends Notification {
+  click_action?: string
+  actions?: NotificationActions
+}
+
+export type AppPushNotificationData = Omit<
+  FcmNotificationData<"answer">,
+  "questionAuthorId"
+>
+
+export type AppNotificationClickData = AppPushNotificationData & {
+  type: NotificationType
+  click_action?: string
+}
+
+export interface AppPushNotificationDataJSON {
+  data: AppPushNotificationData
+  notification: AppPushNotification
+  fcmMessageId: string
+  priority: string
+}

--- a/src/interfaces/push/push-type.ts
+++ b/src/interfaces/push/push-type.ts
@@ -1,0 +1,3 @@
+type NotificationAnswerType = "answer:view" | "answer:close"
+
+export type NotificationType = NotificationAnswerType

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "esnext", "WebWorker"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
## 관련 이슈

#367

## 개요

> 액션버튼(글보기) 클릭시 새 창 열리지 않는 문제 개선, 타입 리팩토링

## 상세 내용

- api에서 link 주소를 전달하고 알림 클릭 이벤트에서 해당 주소를 활용하도록 수정
- firebase-messaging-sw 서비스워커에서 기본 제공해주는 WebWorker 관련 타입을 사용할 수 있도록 타입 관련 작업
  - tsconfig.json : lib에 WebWoker 추가
  - interface/push : 서비스워커에서 사용할 푸시 알림 관련 타입 추가
  - firebase-messaging-sw.js: jsdoc import 로 관련 타입 활용 및 상단에 reference lib WebWorker 적용하여 기본 타입 적용될 수 있도록 함
