### PR TITLE
fix: 알림 아이콘 수정, 액션 제거

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -17,8 +17,8 @@ self.addEventListener("push", (/** @type {PushEvent} */ event) => {
       requireInteraction: true,
       body: notification.body,
       badge: notification.badge ?? "/icons/outline-badge-icon.png",
+      image: notification.image,
       icon: notification.icon ?? "/icon.png",
-      actions: notification.actions ?? actions[data.type],
       data: {
         ...data,
         ...(notification.click_action && {
@@ -32,8 +32,6 @@ self.addEventListener("push", (/** @type {PushEvent} */ event) => {
 self.addEventListener(
   "notificationclick",
   async function (/** @type {NotificationEvent} */ event) {
-    /** @type {import ('../src/interfaces/push/push-action').NotificationAction['action']} */
-    const action = event.action
     /** @type {import ("../src/interfaces/push/push-notification").AppPushNotification} */
     const notification = event.notification
     /** @type {import ("../src/interfaces/push/push-notification").AppNotificationClickData} */
@@ -43,12 +41,10 @@ self.addEventListener(
     const worker = event.currentTarget
 
     if (data.type === "answer") {
-      if (action === "answer:close") return
+      notification.close()
 
       const linkUrl =
         data.click_action ?? `https://kernelsquare.live/question/${data.postId}`
-
-      notification.close()
 
       event.waitUntil(worker.clients.openWindow(linkUrl))
     }

--- a/src/app/api/send-fcm/route.ts
+++ b/src/app/api/send-fcm/route.ts
@@ -43,7 +43,7 @@ export async function POST(request: NextRequest) {
   const notification = payload.notification
 
   if (type === "answer" && isAppNotificationPayload("answer", notification)) {
-    const { data, ...notificationPayload } = notification
+    const { data, icon, ...notificationPayload } = notification
 
     const { postId, questionAuthorId } = data
 
@@ -78,17 +78,7 @@ export async function POST(request: NextRequest) {
                   badge:
                     process.env.NEXT_PUBLIC_SITE_URL +
                     "/icons/outline-badge-icon.png",
-                  icon: process.env.NEXT_PUBLIC_SITE_URL + "/icon.png",
-                  actions: [
-                    {
-                      action: "answer:view",
-                      title: "글 보기",
-                    },
-                    {
-                      action: "answer:close",
-                      title: "알림 닫기",
-                    },
-                  ],
+                  icon: icon ?? `${process.env.NEXT_PUBLIC_SITE_URL}/icon.png`,
                 },
                 fcmOptions: {
                   link: `${process.env.NEXT_PUBLIC_SITE_URL}/question/${postId}`,

--- a/src/interfaces/dto/fcm/send-fcm.dto.ts
+++ b/src/interfaces/dto/fcm/send-fcm.dto.ts
@@ -12,6 +12,7 @@ export type FcmNotification<TData extends NotificationType> = {
   title: string
   body: string
   imageUrl?: string
+  icon?: string
   data: FcmNotificationData<TData>
 }
 

--- a/src/interfaces/push/push-action.ts
+++ b/src/interfaces/push/push-action.ts
@@ -1,8 +1,0 @@
-import { NotificationType } from "./push-type"
-
-export interface NotificationAction {
-  action: NotificationType
-  title: string
-}
-
-export type NotificationActions = NotificationAction[]

--- a/src/interfaces/push/push-notification.ts
+++ b/src/interfaces/push/push-notification.ts
@@ -1,18 +1,18 @@
 import { FcmNotificationData, NotificationType } from "../dto/fcm/send-fcm.dto"
-import { NotificationActions } from "./push-action"
 
 export interface AppPushNotification extends Notification {
+  image?: string
   click_action?: string
-  actions?: NotificationActions
 }
 
 export type AppPushNotificationData = Omit<
   FcmNotificationData<"answer">,
   "questionAuthorId"
->
+> & {
+  type: NotificationType
+}
 
 export type AppNotificationClickData = AppPushNotificationData & {
-  type: NotificationType
   click_action?: string
 }
 

--- a/src/interfaces/push/push-type.ts
+++ b/src/interfaces/push/push-type.ts
@@ -1,3 +1,0 @@
-type NotificationAnswerType = "answer:view" | "answer:close"
-
-export type NotificationType = NotificationAnswerType

--- a/src/page/qna-detail/components/Answers/form/CreateAnswerForm.tsx
+++ b/src/page/qna-detail/components/Answers/form/CreateAnswerForm.tsx
@@ -49,6 +49,7 @@ function CreateAnswerForm({ question }: CreateAnswerFormProps) {
           postId: `${question.id}`,
           questionAuthorId: `${question.member_id}`,
         },
+        ...(user?.image_url && { icon: user.image_url }),
       })
 
       setTimeout(() => {


### PR DESCRIPTION
## 관련 이슈

#367

## 개요

> 답변 푸시 알림 아이콘 수정, actions 제거

## 상세 내용

- 답변 알림 시 유저 프로필 이미지가 있을 경우 프로필 이미지 주소를 아이콘으로 설정
- 알림 actions 제거, actions 관련 타입 제거
  - 모바일 백그라운드 상태에서 알림 표시는 되지만, 클릭시 clients.openWindow 가 되지 않음
  - 데스크탑에서는 잘되지만, 모바일에서 액션 버튼(문구)가 노출은 되지만 실제 클릭시 모든 경우에 대응할 수 없음 
  => 일관된 경험을 제공하기 위해 actions는 적용하지 않음
